### PR TITLE
simple_inline_text_annotationクラスを作成 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,6 @@ Style/StringLiterals:
 
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
+
+Style/Documentation:
+  Enabled: false

--- a/lib/simple_inline_text_annotation.rb
+++ b/lib/simple_inline_text_annotation.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require_relative "simple_inline_text_annotation/version"
+require_relative "simple_inline_text_annotation/generator"
+require_relative "simple_inline_text_annotation/parser"
 
 class SimpleInlineTextAnnotation
   # ENTITY_TYPE_PATTERN matches a pair of square brackets which is followed by a colon and URL.

--- a/lib/simple_inline_text_annotation.rb
+++ b/lib/simple_inline_text_annotation.rb
@@ -2,7 +2,70 @@
 
 require_relative "simple_inline_text_annotation/version"
 
-module SimpleInlineTextAnnotation
-  class Error < StandardError; end
-  # Your code goes here...
+class SimpleInlineTextAnnotation
+  # ENTITY_TYPE_PATTERN matches a pair of square brackets which is followed by a colon and URL.
+  # Similar to Markdown, this also matches when there is text enclosed in "" or '' after the URL.
+  # Match example:
+  #  - [Label]: URL
+  #  - [Label]: URL "text"
+  ENTITY_TYPE_PATTERN = /^\s*\[([^\]]+)\]:\s+(\S+)(?:\s+(?:"[^"]*"|'[^']*'))?\s*$/
+
+  # ENTITY_TYPE_BLOCK_PATTERN matches a block of the entity type definitions.
+  # Requires a blank line above the block definition.
+  ENTITY_TYPE_BLOCK_PATTERN = /(?:\A|\n\s*\n)((?:#{ENTITY_TYPE_PATTERN}(?:\n|$))+)/
+
+  # ESCAPE_PATTERN matches a backslash (\) preceding two consecutive pairs of square brackets.
+  # Example: \[This is a part of][original text]
+  ESCAPE_PATTERN = /\\(?=\[[^\]]+\]\[[^\]]+\])/
+
+  def initialize(text, denotations, entity_type_collection)
+    @text = text
+    @denotations = denotations
+    @entity_type_collection = entity_type_collection
+  end
+
+  def self.parse(source)
+    result = SimpleInlineTextAnnotation::Parser.new(source).parse
+    result.to_h
+  end
+
+  def self.generate(source)
+    SimpleInlineTextAnnotation::Generator.new(source).generate
+  end
+
+  def to_h
+    {
+      text: format_text(@text),
+      denotations: @denotations.map(&:to_h),
+      config: config
+    }.compact
+  end
+
+  private
+
+  def format_text(text)
+    result = remove_escape_backslash_from(text)
+    result = reduce_consecutive_newlines_from(result)
+
+    result
+  end
+
+  # Remove backslashes used to escape inline annotation format.
+  # For example, `\[Elon Musk][Person]` is treated as plain text
+  # rather than an annotation. This method removes the leading
+  # backslash and keeps the text as `[Elon Musk][Person]`.
+  def remove_escape_backslash_from(text)
+    text.gsub(ESCAPE_PATTERN, '')
+  end
+
+  # Reduce consecutive newlines to a single newline.
+  def reduce_consecutive_newlines_from(text)
+    text.gsub(/\n{2,}/, "\n\n")
+  end
+
+  def config
+    return nil unless @entity_type_collection.any?
+
+    { "entity types": @entity_type_collection.to_config }
+  end
 end

--- a/lib/simple_inline_text_annotation.rb
+++ b/lib/simple_inline_text_annotation.rb
@@ -47,9 +47,7 @@ class SimpleInlineTextAnnotation
 
   def format_text(text)
     result = remove_escape_backslash_from(text)
-    result = reduce_consecutive_newlines_from(result)
-
-    result
+    reduce_consecutive_newlines_from(result)
   end
 
   # Remove backslashes used to escape inline annotation format.
@@ -57,7 +55,7 @@ class SimpleInlineTextAnnotation
   # rather than an annotation. This method removes the leading
   # backslash and keeps the text as `[Elon Musk][Person]`.
   def remove_escape_backslash_from(text)
-    text.gsub(ESCAPE_PATTERN, '')
+    text.gsub(ESCAPE_PATTERN, "")
   end
 
   # Reduce consecutive newlines to a single newline.

--- a/lib/simple_inline_text_annotation/denotation.rb
+++ b/lib/simple_inline_text_annotation/denotation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "denotation_validator"
 require_relative "generator_error"
 
@@ -28,7 +30,7 @@ class SimpleInlineTextAnnotation
     end
 
     def position_negative?
-      @begin_pos < 0 || @end_pos < 0
+      @begin_pos.negative? || @end_pos.negative?
     end
 
     def position_invalid?

--- a/lib/simple_inline_text_annotation/denotation.rb
+++ b/lib/simple_inline_text_annotation/denotation.rb
@@ -1,0 +1,46 @@
+class SimpleInlineTextAnnotation
+  class Denotation
+    attr_reader :begin_pos, :end_pos, :obj
+
+    def initialize(begin_pos, end_pos, obj)
+      @begin_pos = begin_pos
+      @end_pos = end_pos
+      @obj = obj
+    end
+
+    def span
+      { begin: @begin_pos, end: @end_pos }
+    end
+
+    def to_h
+      { span: span, obj: @obj }
+    end
+
+    def nested_within?(other)
+      other.begin_pos <= @begin_pos && @end_pos <= other.end_pos
+    end
+
+    def position_not_integer?
+      !(@begin_pos.is_a?(Integer) && @end_pos.is_a?(Integer))
+    end
+
+    def position_negative?
+      @begin_pos < 0 || @end_pos < 0
+    end
+
+    def position_invalid?
+      @begin_pos > @end_pos
+    end
+
+    def out_of_bounds?(text_length)
+      @begin_pos >= text_length || @end_pos > text_length
+    end
+
+    def boundary_crossing?(other)
+      starts_inside_other = @begin_pos > other.begin_pos && @begin_pos < other.end_pos
+      ends_inside_other = @end_pos > other.begin_pos && @end_pos < other.end_pos
+
+      starts_inside_other || ends_inside_other
+    end
+  end
+end

--- a/lib/simple_inline_text_annotation/denotation.rb
+++ b/lib/simple_inline_text_annotation/denotation.rb
@@ -1,3 +1,6 @@
+require_relative "denotation_validator"
+require_relative "generator_error"
+
 class SimpleInlineTextAnnotation
   class Denotation
     attr_reader :begin_pos, :end_pos, :obj

--- a/lib/simple_inline_text_annotation/denotation_validator.rb
+++ b/lib/simple_inline_text_annotation/denotation_validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SimpleInlineTextAnnotation
   module DenotationValidator
     def validate(denotations, text_length)
@@ -13,19 +15,19 @@ class SimpleInlineTextAnnotation
     private
 
     def remove_duplicates_from(denotations)
-      denotations.uniq { |denotation| denotation.span }
+      denotations.uniq(&:span)
     end
 
     def remove_non_integer_positions_from(denotations)
-      denotations.reject { |denotation| denotation.position_not_integer? }
+      denotations.reject(&:position_not_integer?)
     end
 
     def remove_negative_positions_from(denotations)
-      denotations.reject { |denotation| denotation.position_negative? }
+      denotations.reject(&:position_negative?)
     end
 
     def remove_invalid_positions_from(denotations)
-      denotations.reject { |denotation| denotation.position_invalid? }
+      denotations.reject(&:position_invalid?)
     end
 
     def remove_out_of_bound_positions_from(denotations, text_length)

--- a/lib/simple_inline_text_annotation/denotation_validator.rb
+++ b/lib/simple_inline_text_annotation/denotation_validator.rb
@@ -1,0 +1,53 @@
+class SimpleInlineTextAnnotation
+  module DenotationValidator
+    def validate(denotations, text_length)
+      result = remove_duplicates_from(denotations)
+      result = remove_non_integer_positions_from(result)
+      result = remove_negative_positions_from(result)
+      result = remove_invalid_positions_from(result)
+      result = remove_out_of_bound_positions_from(result, text_length)
+      result = remove_nests_from(result)
+      remove_boundary_crosses_from(result)
+    end
+
+    private
+
+    def remove_duplicates_from(denotations)
+      denotations.uniq { |denotation| denotation.span }
+    end
+
+    def remove_non_integer_positions_from(denotations)
+      denotations.reject { |denotation| denotation.position_not_integer? }
+    end
+
+    def remove_negative_positions_from(denotations)
+      denotations.reject { |denotation| denotation.position_negative? }
+    end
+
+    def remove_invalid_positions_from(denotations)
+      denotations.reject { |denotation| denotation.position_invalid? }
+    end
+
+    def remove_out_of_bound_positions_from(denotations, text_length)
+      denotations.reject { |denotation| denotation.out_of_bounds?(text_length) }
+    end
+
+    def remove_nests_from(denotations)
+      # Sort by begin_pos in ascending order. If begin_pos is the same, sort by end_pos in descending order.
+      sorted_denotations = denotations.sort_by { |d| [d.begin_pos, -d.end_pos] }
+      result = []
+
+      sorted_denotations.each do |denotation|
+        result << denotation unless result.any? { |outer| denotation.nested_within?(outer) }
+      end
+
+      result
+    end
+
+    def remove_boundary_crosses_from(denotations)
+      denotations.reject do |denotation|
+        denotations.any? { |existing| denotation.boundary_crossing?(existing) }
+      end
+    end
+  end
+end

--- a/lib/simple_inline_text_annotation/entity_type_collection.rb
+++ b/lib/simple_inline_text_annotation/entity_type_collection.rb
@@ -1,0 +1,57 @@
+class SimpleInlineTextAnnotation
+  class EntityTypeCollection
+    def initialize(source)
+      @source = source
+    end
+
+    def get(label)
+      entity_types[label]
+    end
+
+    # to_config returns a Array of hashes of each entity type.
+    # Example:
+    #   [
+    #     {id: "https://example.com/Person", label: "Person"},
+    #     {id: "https://example.com/Organization", label: "Organization"}
+    #   ]
+    def to_config
+      entity_types.map do |label, id|
+        { id: id, label: label }
+      end
+    end
+
+    def any?
+      entity_types.any?
+    end
+
+    private
+
+    # entity_types returns a Hash structured with label as key and id as value.
+    # Example:
+    #   {
+    #     "Person": "https://example.com/Person",
+    #     "Organization": "https://example.com/Organization"
+    #   }
+    def entity_types
+      @entity_types ||= read_entities_from_source
+    end
+
+    def read_entities_from_source
+      entity_types = {}
+
+      @source.scan(ENTITY_TYPE_BLOCK_PATTERN).each do |entity_block|
+        entity_block[0].each_line do |line|
+          match = line.strip.match(ENTITY_TYPE_PATTERN)
+          next unless match
+
+          label, id = match[1], match[2]
+          next if label == id # Do not create entity_type if label and id is same.
+
+          entity_types[label] ||= id
+        end
+      end
+
+      entity_types
+    end
+  end
+end

--- a/lib/simple_inline_text_annotation/entity_type_collection.rb
+++ b/lib/simple_inline_text_annotation/entity_type_collection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SimpleInlineTextAnnotation
   class EntityTypeCollection
     def initialize(source)
@@ -44,7 +46,8 @@ class SimpleInlineTextAnnotation
           match = line.strip.match(ENTITY_TYPE_PATTERN)
           next unless match
 
-          label, id = match[1], match[2]
+          label = match[1]
+          id = match[2]
           next if label == id # Do not create entity_type if label and id is same.
 
           entity_types[label] ||= id

--- a/lib/simple_inline_text_annotation/entity_type_collection.rb
+++ b/lib/simple_inline_text_annotation/entity_type_collection.rb
@@ -42,19 +42,27 @@ class SimpleInlineTextAnnotation
       entity_types = {}
 
       @source.scan(ENTITY_TYPE_BLOCK_PATTERN).each do |entity_block|
-        entity_block[0].each_line do |line|
-          match = line.strip.match(ENTITY_TYPE_PATTERN)
-          next unless match
-
-          label = match[1]
-          id = match[2]
-          next if label == id # Do not create entity_type if label and id is same.
-
-          entity_types[label] ||= id
-        end
+        process_entity_block(entity_block, entity_types)
       end
 
       entity_types
+    end
+
+    def process_entity_block(entity_block, entity_types)
+      entity_block[0].each_line do |line|
+        process_entity_line(line, entity_types)
+      end
+    end
+
+    def process_entity_line(line, entity_types)
+      match = line.strip.match(ENTITY_TYPE_PATTERN)
+      return unless match
+
+      label = match[1]
+      id = match[2]
+      return if label == id # Do not create entity_type if label and id is same.
+
+      entity_types[label] ||= id
     end
   end
 end

--- a/lib/simple_inline_text_annotation/generator.rb
+++ b/lib/simple_inline_text_annotation/generator.rb
@@ -1,3 +1,5 @@
+require_relative "denotation"
+
 class SimpleInlineTextAnnotation
   class Generator
     include DenotationValidator
@@ -53,7 +55,7 @@ class SimpleInlineTextAnnotation
     end
 
     def build_label_definitions
-      return nil if labeled_entity_types.blank?
+      return nil if labeled_entity_types.nil? || labeled_entity_types.empty?
 
       labeled_entity_types.map do |entity|
         "[#{entity["label"]}]: #{entity["id"]}"

--- a/lib/simple_inline_text_annotation/generator.rb
+++ b/lib/simple_inline_text_annotation/generator.rb
@@ -1,0 +1,63 @@
+class SimpleInlineTextAnnotation
+  class Generator
+    include DenotationValidator
+
+    def initialize(source)
+      @source = source.dup.freeze
+      @denotations = build_denotations(source["denotations"] || [])
+      @config = @source["config"]
+    end
+
+    def generate
+      text = @source["text"]
+      raise SimpleInlineTextAnnotation::GeneratorError, 'The "text" key is missing.' if text.nil?
+      denotations = validate(@denotations, text.length)
+
+      annotated_text = annotate_text(text, denotations)
+      label_definitions = build_label_definitions
+
+      [annotated_text, label_definitions].compact.join("\n\n")
+    end
+
+    private
+
+    def build_denotations(denotations)
+      denotations.map { |d| Denotation.new(d["span"]["begin"], d["span"]["end"], d["obj"]) }
+    end
+
+    def annotate_text(text, denotations)
+      # Annotate text from the end to ensure position calculation.
+      denotations.sort_by(&:begin_pos).reverse_each do |denotation|
+        begin_pos = denotation.begin_pos
+        end_pos = denotation.end_pos
+        obj = get_obj(denotation.obj)
+
+        annotated_text = "[#{text[begin_pos...end_pos]}][#{obj}]"
+        text = text[0...begin_pos] + annotated_text + text[end_pos..]
+      end
+
+      text
+    end
+
+    def labeled_entity_types
+      return nil unless @config
+
+      @config["entity types"]&.select { |entity_type| entity_type.key?("label") }
+    end
+
+    def get_obj(obj)
+      return obj unless labeled_entity_types
+
+      entity = labeled_entity_types.find { |entity_type| entity_type["id"] == obj }
+      entity ? entity["label"] : obj
+    end
+
+    def build_label_definitions
+      return nil if labeled_entity_types.blank?
+
+      labeled_entity_types.map do |entity|
+        "[#{entity["label"]}]: #{entity["id"]}"
+      end.join("\n")
+    end
+  end
+end

--- a/lib/simple_inline_text_annotation/generator.rb
+++ b/lib/simple_inline_text_annotation/generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "denotation"
 
 class SimpleInlineTextAnnotation
@@ -13,6 +15,7 @@ class SimpleInlineTextAnnotation
     def generate
       text = @source["text"]
       raise SimpleInlineTextAnnotation::GeneratorError, 'The "text" key is missing.' if text.nil?
+
       denotations = validate(@denotations, text.length)
 
       annotated_text = annotate_text(text, denotations)

--- a/lib/simple_inline_text_annotation/generator_error.rb
+++ b/lib/simple_inline_text_annotation/generator_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SimpleInlineTextAnnotation
   class GeneratorError < StandardError
     def initialize(msg = nil)

--- a/lib/simple_inline_text_annotation/generator_error.rb
+++ b/lib/simple_inline_text_annotation/generator_error.rb
@@ -1,0 +1,7 @@
+class SimpleInlineTextAnnotation
+  class GeneratorError < StandardError
+    def initialize(msg = nil)
+      super(msg)
+    end
+  end
+end

--- a/lib/simple_inline_text_annotation/parser.rb
+++ b/lib/simple_inline_text_annotation/parser.rb
@@ -1,4 +1,6 @@
-require_relative 'entity_type_collection'
+# frozen_string_literal: true
+
+require_relative "entity_type_collection"
 require_relative "denotation"
 
 class SimpleInlineTextAnnotation

--- a/lib/simple_inline_text_annotation/parser.rb
+++ b/lib/simple_inline_text_annotation/parser.rb
@@ -1,3 +1,6 @@
+require_relative 'entity_type_collection'
+require_relative "denotation"
+
 class SimpleInlineTextAnnotation
   class Parser
     # DENOTATION_PATTERN matches two consecutive pairs of square brackets.

--- a/lib/simple_inline_text_annotation/parser.rb
+++ b/lib/simple_inline_text_annotation/parser.rb
@@ -1,0 +1,51 @@
+class SimpleInlineTextAnnotation
+  class Parser
+    # DENOTATION_PATTERN matches two consecutive pairs of square brackets.
+    # Example: [Annotated Text][Label]
+    DENOTATION_PATTERN = /(?<!\\)\[([^\[]+?)\]\[([^\]]+?)\]/
+
+    def initialize(source)
+      @source = source.dup.freeze
+      @denotations = []
+      @entity_type_collection = EntityTypeCollection.new(source)
+    end
+
+    def parse
+      full_text = source_without_references
+
+      while full_text =~ DENOTATION_PATTERN
+        match = Regexp.last_match
+        target_text = match[1]
+        label = match[2]
+
+        begin_pos = match.begin(0)
+        end_pos = begin_pos + target_text.length
+        obj = get_obj_for(label)
+
+        @denotations << Denotation.new(begin_pos, end_pos, obj)
+
+        # Replace the processed annotation with its text content
+        full_text[match.begin(0)...match.end(0)] = target_text
+      end
+
+      SimpleInlineTextAnnotation.new(
+        full_text,
+        @denotations,
+        @entity_type_collection
+      )
+    end
+
+    private
+
+    # Remove references from the source.
+    def source_without_references
+      @source.gsub(ENTITY_TYPE_BLOCK_PATTERN) do |block|
+        block.start_with?("\n\n") ? "\n\n" : ""
+      end.strip
+    end
+
+    def get_obj_for(label)
+      @entity_type_collection.get(label) || label
+    end
+  end
+end

--- a/lib/simple_inline_text_annotation/parser.rb
+++ b/lib/simple_inline_text_annotation/parser.rb
@@ -18,20 +18,7 @@ class SimpleInlineTextAnnotation
     def parse
       full_text = source_without_references
 
-      while full_text =~ DENOTATION_PATTERN
-        match = Regexp.last_match
-        target_text = match[1]
-        label = match[2]
-
-        begin_pos = match.begin(0)
-        end_pos = begin_pos + target_text.length
-        obj = get_obj_for(label)
-
-        @denotations << Denotation.new(begin_pos, end_pos, obj)
-
-        # Replace the processed annotation with its text content
-        full_text[match.begin(0)...match.end(0)] = target_text
-      end
+      process_denotations(full_text)
 
       SimpleInlineTextAnnotation.new(
         full_text,
@@ -51,6 +38,27 @@ class SimpleInlineTextAnnotation
 
     def get_obj_for(label)
       @entity_type_collection.get(label) || label
+    end
+
+    def process_denotations(full_text)
+      while full_text =~ DENOTATION_PATTERN
+        match = Regexp.last_match
+        process_single_denotation(match, full_text)
+      end
+    end
+
+    def process_single_denotation(match, full_text)
+      target_text = match[1]
+      label = match[2]
+
+      begin_pos = match.begin(0)
+      end_pos = begin_pos + target_text.length
+      obj = get_obj_for(label)
+
+      @denotations << Denotation.new(begin_pos, end_pos, obj)
+
+      # Replace the processed annotation with its text content
+      full_text[match.begin(0)...match.end(0)] = target_text
     end
   end
 end

--- a/lib/simple_inline_text_annotation/version.rb
+++ b/lib/simple_inline_text_annotation/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-module SimpleInlineTextAnnotation
+class SimpleInlineTextAnnotation
   VERSION = "0.1.0"
 end


### PR DESCRIPTION
## 関連issue
close #2 

## 概要
https://github.com/pubannotation/pubannotation/blob/master/app/models/simple_inline_text_annotation.rb 
https://github.com/pubannotation/pubannotation/tree/master/app/models/simple_inline_text_annotation

以上からsimple_inline_text_annotation gemを動作させるためのファイルを引っ張ってきました。
また、rubocopで警告された部分の修正を行なっています。

## 動作確認
- 動作確認のため、一度`gem build simple_inline_text_annotation.gemspec`を実行しました
- 以下の二つのファイルを作成しました
```ruby
require 'simple_inline_text_annotation'

# テスト用のデータ
source = {
  "text" => "Elon Musk is a member of the PayPal Mafia.",
  "denotations" => [
    { "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
    { "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
  ]
}

# 期待されるフォーマット
expected_format = '[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].'

# 実際の出力を生成
result = SimpleInlineTextAnnotation.generate(source)

# 結果を比較して出力
if result == expected_format
  puts "Test passed! Output: #{result}"
else
  puts "Test failed!"
  puts "Expected: #{expected_format}"
  puts "Got: #{result}"
end
```

```ruby
require 'simple_inline_text_annotation'

# テスト用のデータ
source = '[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].'

# 期待されるフォーマット
expected_format = {
  text: "Elon Musk is a member of the PayPal Mafia.",
  denotations: [
    { span: { begin: 0, end: 9 }, obj: "Person" },
    { span: { begin: 29, end: 41 }, obj: "Organization" }
  ]
}

# 実際の出力を生成
parser = SimpleInlineTextAnnotation::Parser.new(source)
result = parser.parse

# 結果を比較して出力
if result.to_h == expected_format
  puts "Test passed! Output: #{result.to_h}"
else
  puts "Test failed!"
  puts "Expected: #{expected_format}"
  puts "Got: #{result.to_h}"
end
```
- この二つのファイルを実行し、それぞれ期待されるフォーマットで帰ってくることを確認しました。