### PR TITLE
Issue 3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,3 +9,7 @@ Style/StringLiteralsInInterpolation:
 
 Style/Documentation:
   Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'

--- a/spec/simple_inline_text_annotation/generator_spec.rb
+++ b/spec/simple_inline_text_annotation/generator_spec.rb
@@ -1,0 +1,217 @@
+require 'spec_helper'
+
+RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
+  describe '#generate' do
+    subject { SimpleInlineTextAnnotation.generate(source) }
+
+    context 'when source has denotations' do
+      let(:source) { {
+        "text" => "Elon Musk is a member of the PayPal Mafia.",
+        "denotations" => [
+          {"span" => {"begin" => 0, "end" => 9}, "obj" => "Person"},
+          {"span" => {"begin" => 29, "end" => 41}, "obj" => "Organization"},
+        ]
+      } }
+      let(:expected_format) { '[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].' }
+
+      it 'generate annotation structure' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context 'when source has config' do
+      let(:source) { {
+        "text" => "Elon Musk is a member of the PayPal Mafia.",
+        "denotations" => [
+            {"span" => {"begin" => 0, "end" => 9}, "obj" => "https://example.com/Person"},
+            {"span" => {"begin" => 29, "end" => 41}, "obj" => "https://example.com/Organization"},
+          ],
+        "config" => {
+          "entity types" => [
+            { "id" => "https://example.com/Person", "label" => "Person" },
+            { "id" => "https://example.com/Organization", "label" => "Organization" }
+          ]
+        }
+      } }
+      let(:expected_format) do
+        <<~MD2.chomp
+          [Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
+
+          [Person]: https://example.com/Person
+          [Organization]: https://example.com/Organization
+        MD2
+      end
+
+      it 'generate label definition structure' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context 'when entity type has present but label is missing' do
+      let(:source) { {
+        "text" => "Elon Musk is a member of the PayPal Mafia.",
+        "denotations" => [
+          {"span" => {"begin" => 0, "end" => 9}, "obj" => "Person"}
+        ],
+        "config" => {
+          "entity types" => [
+            {"id" => "Person"}
+          ]
+        }
+      }}
+
+      let(:expected_format) { '[Elon Musk][Person] is a member of the PayPal Mafia.' }
+
+      it 'should create only annotation structure' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context 'when span value is not integer' do
+      let(:source) { {
+        "text" => "Elon Musk is a member of the PayPal Mafia.",
+        "denotations" => [
+          {"span" => {"begin" => 0.1, "end" => 9.6}, "obj" => "Person"},
+          {"span" => {"begin" => "0", "end" => "9"}, "obj" => "Organization"}
+        ]
+      }}
+
+      let(:expected_format) { 'Elon Musk is a member of the PayPal Mafia.' }
+
+      it 'should not parse as annotation' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context 'when source has same span denotations' do
+      let(:source) { {
+        "text" => "Elon Musk is a member of the PayPal Mafia.",
+        "denotations" => [
+          {"span" => {"begin" => 0, "end" => 9}, "obj" => "Person"},
+          {"span" => {"begin" => 0, "end" => 9}, "obj" => "Organization"},
+        ]
+      } }
+      let(:expected_format) { '[Elon Musk][Person] is a member of the PayPal Mafia.' }
+
+      it 'should use first denotation' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context 'when source has nested span within another span' do
+      context 'when both begin and end are inside' do
+        let(:source) { {
+          "text" => "Elon Musk is a member of the PayPal Mafia.",
+          "denotations" => [
+            {"span" => {"begin" => 0, "end" => 9}, "obj" => "Person"},
+            {"span" => {"begin" => 2, "end" => 6}, "obj" => "Organization"},
+          ]
+        } }
+        let(:expected_format) { '[Elon Musk][Person] is a member of the PayPal Mafia.' }
+
+        it 'should use only outer denotation' do
+          is_expected.to eq(expected_format)
+        end
+      end
+
+      context 'when begin is inside' do
+        let(:source) { {
+          "text" => "Elon Musk is a member of the PayPal Mafia.",
+          "denotations" => [
+            {"span" => {"begin" => 0, "end" => 4}, "obj" => "First name"},
+            {"span" => {"begin" => 0, "end" => 9}, "obj" => "Full name"},
+          ]
+        } }
+        let(:expected_format) { '[Elon Musk][Full name] is a member of the PayPal Mafia.' }
+
+        it 'should use only outer denotation' do
+          is_expected.to eq(expected_format)
+        end
+      end
+
+      context 'when end is inside' do
+        let(:source) { {
+          "text" => "Elon Musk is a member of the PayPal Mafia.",
+          "denotations" => [
+            {"span" => {"begin" => 6, "end" => 9}, "obj" => "Last name"},
+            {"span" => {"begin" => 0, "end" => 9}, "obj" => "Full name"},
+          ]
+        } }
+        let(:expected_format) { '[Elon Musk][Full name] is a member of the PayPal Mafia.' }
+
+        it 'should use only outer denotation' do
+          is_expected.to eq(expected_format)
+        end
+      end
+    end
+
+    context 'when source has boundary-crossing denotations' do
+      let(:source) { {
+        "text" => "Elon Musk is a member of the PayPal Mafia.",
+        "denotations" => [
+          {"span" => {"begin" => 0, "end" => 9}, "obj" => "Person"},
+          {"span" => {"begin" => 8, "end" => 11}, "obj" => "Organization"},
+        ]
+      } }
+      let(:expected_format) { 'Elon Musk is a member of the PayPal Mafia.' }
+
+      it 'should be both ignored' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context 'when denotations span is negative' do
+      let(:source) { {
+        "text" => "Elon Musk is a member of the PayPal Mafia.",
+        "denotations" => [
+          {"span" => {"begin" => -1, "end" => 9}, "obj" => "Person"},
+        ]
+      } }
+      let(:expected_format) { 'Elon Musk is a member of the PayPal Mafia.' }
+
+      it 'should be ignored' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context 'when denotations span is invalid' do
+      let(:source) { {
+        "text" => "Elon Musk is a member of the PayPal Mafia.",
+        "denotations" => [
+          {"span" => {"begin" => 4, "end" => 0}, "obj" => "Person"},
+        ]
+      } }
+      let(:expected_format) { 'Elon Musk is a member of the PayPal Mafia.' }
+
+      it 'should be ignored' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context 'when denotation is out of bound with text length' do
+      let(:source) { {
+        "text" => "Elon Musk is a member of the PayPal Mafia.",
+        "denotations" => [
+          {"span" => {"begin" => 100, "end" => 200}, "obj" => "Person"},
+        ]
+      } }
+      let(:expected_format) { 'Elon Musk is a member of the PayPal Mafia.' }
+
+      it 'should be ignored' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context 'when source text key is missing' do
+      let(:source) { {
+        "denotations" => [
+          {"span" => {"begin" => 4, "end" => 0}, "obj" => "Person"},
+        ]
+      } }
+
+      it 'raises GeneratorError' do
+        expect { subject }.to raise_error(SimpleInlineTextAnnotation::GeneratorError, 'The "text" key is missing.')
+      end
+    end
+  end
+end

--- a/spec/simple_inline_text_annotation/generator_spec.rb
+++ b/spec/simple_inline_text_annotation/generator_spec.rb
@@ -1,38 +1,44 @@
-require 'spec_helper'
+# frozen_string_literal: true
+
+require "spec_helper"
 
 RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
-  describe '#generate' do
+  describe "#generate" do
     subject { SimpleInlineTextAnnotation.generate(source) }
 
-    context 'when source has denotations' do
-      let(:source) { {
-        "text" => "Elon Musk is a member of the PayPal Mafia.",
-        "denotations" => [
-          {"span" => {"begin" => 0, "end" => 9}, "obj" => "Person"},
-          {"span" => {"begin" => 29, "end" => 41}, "obj" => "Organization"},
-        ]
-      } }
-      let(:expected_format) { '[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].' }
+    context "when source has denotations" do
+      let(:source) do
+        {
+          "text" => "Elon Musk is a member of the PayPal Mafia.",
+          "denotations" => [
+            { "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+            { "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
+          ]
+        }
+      end
+      let(:expected_format) { "[Elon Musk][Person] is a member of the [PayPal Mafia][Organization]." }
 
-      it 'generate annotation structure' do
+      it "generate annotation structure" do
         is_expected.to eq(expected_format)
       end
     end
 
-    context 'when source has config' do
-      let(:source) { {
-        "text" => "Elon Musk is a member of the PayPal Mafia.",
-        "denotations" => [
-            {"span" => {"begin" => 0, "end" => 9}, "obj" => "https://example.com/Person"},
-            {"span" => {"begin" => 29, "end" => 41}, "obj" => "https://example.com/Organization"},
+    context "when source has config" do
+      let(:source) do
+        {
+          "text" => "Elon Musk is a member of the PayPal Mafia.",
+          "denotations" => [
+            { "span" => { "begin" => 0, "end" => 9 }, "obj" => "https://example.com/Person" },
+            { "span" => { "begin" => 29, "end" => 41 }, "obj" => "https://example.com/Organization" }
           ],
-        "config" => {
-          "entity types" => [
-            { "id" => "https://example.com/Person", "label" => "Person" },
-            { "id" => "https://example.com/Organization", "label" => "Organization" }
-          ]
+          "config" => {
+            "entity types" => [
+              { "id" => "https://example.com/Person", "label" => "Person" },
+              { "id" => "https://example.com/Organization", "label" => "Organization" }
+            ]
+          }
         }
-      } }
+      end
       let(:expected_format) do
         <<~MD2.chomp
           [Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
@@ -42,174 +48,196 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         MD2
       end
 
-      it 'generate label definition structure' do
+      it "generate label definition structure" do
         is_expected.to eq(expected_format)
       end
     end
 
-    context 'when entity type has present but label is missing' do
-      let(:source) { {
-        "text" => "Elon Musk is a member of the PayPal Mafia.",
-        "denotations" => [
-          {"span" => {"begin" => 0, "end" => 9}, "obj" => "Person"}
-        ],
-        "config" => {
-          "entity types" => [
-            {"id" => "Person"}
+    context "when entity type has present but label is missing" do
+      let(:source) do
+        {
+          "text" => "Elon Musk is a member of the PayPal Mafia.",
+          "denotations" => [
+            { "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" }
+          ],
+          "config" => {
+            "entity types" => [
+              { "id" => "Person" }
+            ]
+          }
+        }
+      end
+
+      let(:expected_format) { "[Elon Musk][Person] is a member of the PayPal Mafia." }
+
+      it "should create only annotation structure" do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context "when span value is not integer" do
+      let(:source) do
+        {
+          "text" => "Elon Musk is a member of the PayPal Mafia.",
+          "denotations" => [
+            { "span" => { "begin" => 0.1, "end" => 9.6 }, "obj" => "Person" },
+            { "span" => { "begin" => "0", "end" => "9" }, "obj" => "Organization" }
           ]
         }
-      }}
+      end
 
-      let(:expected_format) { '[Elon Musk][Person] is a member of the PayPal Mafia.' }
+      let(:expected_format) { "Elon Musk is a member of the PayPal Mafia." }
 
-      it 'should create only annotation structure' do
+      it "should not parse as annotation" do
         is_expected.to eq(expected_format)
       end
     end
 
-    context 'when span value is not integer' do
-      let(:source) { {
-        "text" => "Elon Musk is a member of the PayPal Mafia.",
-        "denotations" => [
-          {"span" => {"begin" => 0.1, "end" => 9.6}, "obj" => "Person"},
-          {"span" => {"begin" => "0", "end" => "9"}, "obj" => "Organization"}
-        ]
-      }}
-
-      let(:expected_format) { 'Elon Musk is a member of the PayPal Mafia.' }
-
-      it 'should not parse as annotation' do
-        is_expected.to eq(expected_format)
-      end
-    end
-
-    context 'when source has same span denotations' do
-      let(:source) { {
-        "text" => "Elon Musk is a member of the PayPal Mafia.",
-        "denotations" => [
-          {"span" => {"begin" => 0, "end" => 9}, "obj" => "Person"},
-          {"span" => {"begin" => 0, "end" => 9}, "obj" => "Organization"},
-        ]
-      } }
-      let(:expected_format) { '[Elon Musk][Person] is a member of the PayPal Mafia.' }
-
-      it 'should use first denotation' do
-        is_expected.to eq(expected_format)
-      end
-    end
-
-    context 'when source has nested span within another span' do
-      context 'when both begin and end are inside' do
-        let(:source) { {
+    context "when source has same span denotations" do
+      let(:source) do
+        {
           "text" => "Elon Musk is a member of the PayPal Mafia.",
           "denotations" => [
-            {"span" => {"begin" => 0, "end" => 9}, "obj" => "Person"},
-            {"span" => {"begin" => 2, "end" => 6}, "obj" => "Organization"},
+            { "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+            { "span" => { "begin" => 0, "end" => 9 }, "obj" => "Organization" }
           ]
-        } }
-        let(:expected_format) { '[Elon Musk][Person] is a member of the PayPal Mafia.' }
+        }
+      end
+      let(:expected_format) { "[Elon Musk][Person] is a member of the PayPal Mafia." }
 
-        it 'should use only outer denotation' do
+      it "should use first denotation" do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context "when source has nested span within another span" do
+      context "when both begin and end are inside" do
+        let(:source) do
+          {
+            "text" => "Elon Musk is a member of the PayPal Mafia.",
+            "denotations" => [
+              { "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+              { "span" => { "begin" => 2, "end" => 6 }, "obj" => "Organization" }
+            ]
+          }
+        end
+        let(:expected_format) { "[Elon Musk][Person] is a member of the PayPal Mafia." }
+
+        it "should use only outer denotation" do
           is_expected.to eq(expected_format)
         end
       end
 
-      context 'when begin is inside' do
-        let(:source) { {
-          "text" => "Elon Musk is a member of the PayPal Mafia.",
-          "denotations" => [
-            {"span" => {"begin" => 0, "end" => 4}, "obj" => "First name"},
-            {"span" => {"begin" => 0, "end" => 9}, "obj" => "Full name"},
-          ]
-        } }
-        let(:expected_format) { '[Elon Musk][Full name] is a member of the PayPal Mafia.' }
+      context "when begin is inside" do
+        let(:source) do
+          {
+            "text" => "Elon Musk is a member of the PayPal Mafia.",
+            "denotations" => [
+              { "span" => { "begin" => 0, "end" => 4 }, "obj" => "First name" },
+              { "span" => { "begin" => 0, "end" => 9 }, "obj" => "Full name" }
+            ]
+          }
+        end
+        let(:expected_format) { "[Elon Musk][Full name] is a member of the PayPal Mafia." }
 
-        it 'should use only outer denotation' do
+        it "should use only outer denotation" do
           is_expected.to eq(expected_format)
         end
       end
 
-      context 'when end is inside' do
-        let(:source) { {
-          "text" => "Elon Musk is a member of the PayPal Mafia.",
-          "denotations" => [
-            {"span" => {"begin" => 6, "end" => 9}, "obj" => "Last name"},
-            {"span" => {"begin" => 0, "end" => 9}, "obj" => "Full name"},
-          ]
-        } }
-        let(:expected_format) { '[Elon Musk][Full name] is a member of the PayPal Mafia.' }
+      context "when end is inside" do
+        let(:source) do
+          {
+            "text" => "Elon Musk is a member of the PayPal Mafia.",
+            "denotations" => [
+              { "span" => { "begin" => 6, "end" => 9 }, "obj" => "Last name" },
+              { "span" => { "begin" => 0, "end" => 9 }, "obj" => "Full name" }
+            ]
+          }
+        end
+        let(:expected_format) { "[Elon Musk][Full name] is a member of the PayPal Mafia." }
 
-        it 'should use only outer denotation' do
+        it "should use only outer denotation" do
           is_expected.to eq(expected_format)
         end
       end
     end
 
-    context 'when source has boundary-crossing denotations' do
-      let(:source) { {
-        "text" => "Elon Musk is a member of the PayPal Mafia.",
-        "denotations" => [
-          {"span" => {"begin" => 0, "end" => 9}, "obj" => "Person"},
-          {"span" => {"begin" => 8, "end" => 11}, "obj" => "Organization"},
-        ]
-      } }
-      let(:expected_format) { 'Elon Musk is a member of the PayPal Mafia.' }
+    context "when source has boundary-crossing denotations" do
+      let(:source) do
+        {
+          "text" => "Elon Musk is a member of the PayPal Mafia.",
+          "denotations" => [
+            { "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+            { "span" => { "begin" => 8, "end" => 11 }, "obj" => "Organization" }
+          ]
+        }
+      end
+      let(:expected_format) { "Elon Musk is a member of the PayPal Mafia." }
 
-      it 'should be both ignored' do
+      it "should be both ignored" do
         is_expected.to eq(expected_format)
       end
     end
 
-    context 'when denotations span is negative' do
-      let(:source) { {
-        "text" => "Elon Musk is a member of the PayPal Mafia.",
-        "denotations" => [
-          {"span" => {"begin" => -1, "end" => 9}, "obj" => "Person"},
-        ]
-      } }
-      let(:expected_format) { 'Elon Musk is a member of the PayPal Mafia.' }
+    context "when denotations span is negative" do
+      let(:source) do
+        {
+          "text" => "Elon Musk is a member of the PayPal Mafia.",
+          "denotations" => [
+            { "span" => { "begin" => -1, "end" => 9 }, "obj" => "Person" }
+          ]
+        }
+      end
+      let(:expected_format) { "Elon Musk is a member of the PayPal Mafia." }
 
-      it 'should be ignored' do
+      it "should be ignored" do
         is_expected.to eq(expected_format)
       end
     end
 
-    context 'when denotations span is invalid' do
-      let(:source) { {
-        "text" => "Elon Musk is a member of the PayPal Mafia.",
-        "denotations" => [
-          {"span" => {"begin" => 4, "end" => 0}, "obj" => "Person"},
-        ]
-      } }
-      let(:expected_format) { 'Elon Musk is a member of the PayPal Mafia.' }
+    context "when denotations span is invalid" do
+      let(:source) do
+        {
+          "text" => "Elon Musk is a member of the PayPal Mafia.",
+          "denotations" => [
+            { "span" => { "begin" => 4, "end" => 0 }, "obj" => "Person" }
+          ]
+        }
+      end
+      let(:expected_format) { "Elon Musk is a member of the PayPal Mafia." }
 
-      it 'should be ignored' do
+      it "should be ignored" do
         is_expected.to eq(expected_format)
       end
     end
 
-    context 'when denotation is out of bound with text length' do
-      let(:source) { {
-        "text" => "Elon Musk is a member of the PayPal Mafia.",
-        "denotations" => [
-          {"span" => {"begin" => 100, "end" => 200}, "obj" => "Person"},
-        ]
-      } }
-      let(:expected_format) { 'Elon Musk is a member of the PayPal Mafia.' }
+    context "when denotation is out of bound with text length" do
+      let(:source) do
+        {
+          "text" => "Elon Musk is a member of the PayPal Mafia.",
+          "denotations" => [
+            { "span" => { "begin" => 100, "end" => 200 }, "obj" => "Person" }
+          ]
+        }
+      end
+      let(:expected_format) { "Elon Musk is a member of the PayPal Mafia." }
 
-      it 'should be ignored' do
+      it "should be ignored" do
         is_expected.to eq(expected_format)
       end
     end
 
-    context 'when source text key is missing' do
-      let(:source) { {
-        "denotations" => [
-          {"span" => {"begin" => 4, "end" => 0}, "obj" => "Person"},
-        ]
-      } }
+    context "when source text key is missing" do
+      let(:source) do
+        {
+          "denotations" => [
+            { "span" => { "begin" => 4, "end" => 0 }, "obj" => "Person" }
+          ]
+        }
+      end
 
-      it 'raises GeneratorError' do
+      it "raises GeneratorError" do
         expect { subject }.to raise_error(SimpleInlineTextAnnotation::GeneratorError, 'The "text" key is missing.')
       end
     end

--- a/spec/simple_inline_text_annotation/parser_spec.rb
+++ b/spec/simple_inline_text_annotation/parser_spec.rb
@@ -1,25 +1,29 @@
-require 'spec_helper'
+# frozen_string_literal: true
+
+require "spec_helper"
 
 RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
-  describe '#parse' do
+  describe "#parse" do
     subject { SimpleInlineTextAnnotation.parse(source) }
 
-    context 'when source has annotation structure' do
-      let(:source) { '[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].' }
-      let(:expected_format) { {
-        "text": "Elon Musk is a member of the PayPal Mafia.",
-        "denotations":[
-            {"span":{"begin": 0, "end": 9}, "obj":"Person"},
-            {"span":{"begin": 29, "end": 41}, "obj":"Organization"},
+    context "when source has annotation structure" do
+      let(:source) { "[Elon Musk][Person] is a member of the [PayPal Mafia][Organization]." }
+      let(:expected_format) do
+        {
+          "text": "Elon Musk is a member of the PayPal Mafia.",
+          "denotations": [
+            { "span": { "begin": 0, "end": 9 }, "obj": "Person" },
+            { "span": { "begin": 29, "end": 41 }, "obj": "Organization" }
           ]
-      } }
+        }
+      end
 
-      it 'parse as denotation' do
+      it "parse as denotation" do
         is_expected.to eq(expected_format)
       end
     end
 
-    context 'when surce has reference structure' do
+    context "when surce has reference structure" do
       let(:source) do
         <<~MD2
           [Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
@@ -28,85 +32,93 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
           [Organization]: https://example.com/Organization
         MD2
       end
-      let(:expected_format) { {
-        "text": "Elon Musk is a member of the PayPal Mafia.",
-        "denotations":[
-            {"span":{"begin": 0, "end": 9}, "obj":"https://example.com/Person"},
-            {"span":{"begin": 29, "end": 41}, "obj":"https://example.com/Organization"},
+      let(:expected_format) do
+        {
+          "text": "Elon Musk is a member of the PayPal Mafia.",
+          "denotations": [
+            { "span": { "begin": 0, "end": 9 }, "obj": "https://example.com/Person" },
+            { "span": { "begin": 29, "end": 41 }, "obj": "https://example.com/Organization" }
           ],
-        "config": {
-          "entity types": [
-            { "id": "https://example.com/Person", "label": "Person" },
-            { "id": "https://example.com/Organization", "label": "Organization" }
-          ]
+          "config": {
+            "entity types": [
+              { "id": "https://example.com/Person", "label": "Person" },
+              { "id": "https://example.com/Organization", "label": "Organization" }
+            ]
+          }
         }
-      } }
+      end
 
-      it 'parse as entity types and apply id to denotation obj' do
+      it "parse as entity types and apply id to denotation obj" do
         is_expected.to eq(expected_format)
       end
     end
 
-    context 'when source has metacharacter escape' do
+    context "when source has metacharacter escape" do
       let(:source) { '\[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].' }
-      let(:expected_format) { {
-        "text": "[Elon Musk][Person] is a member of the PayPal Mafia.",
-        "denotations":[
-            {"span":{"begin": 40, "end": 52}, "obj":"Organization"}
-          ]
-      } }
-
-      it 'is not parsed as annotation' do
-        is_expected.to eq(expected_format)
-      end
-    end
-
-    context 'when reference definitions do not have a blank line above' do
-      let(:source) do
-        <<~MD2
-          [Elon Musk][Person] is a member of the PayPal Mafia.
-          [Person]: https://example.com/Person
-        MD2
-      end
-      let(:expected_format) { {
-        "text": "Elon Musk is a member of the PayPal Mafia.\n[Person]: https://example.com/Person",
-        "denotations":[
-            {"span":{"begin": 0, "end": 9}, "obj":"Person"}
-          ]
-      } }
-
-      it 'does not use as references' do
-        is_expected.to eq(expected_format)
-      end
-    end
-
-    context 'when reference definitions have a blank line above' do
-      let(:source) do
-        <<~MD2
-          [Elon Musk][Person] is a member of the PayPal Mafia.
-
-          [Person]: https://example.com/Person
-        MD2
-      end
-      let(:expected_format) { {
-        "text": "Elon Musk is a member of the PayPal Mafia.",
-        "denotations":[
-            {"span":{"begin": 0, "end": 9}, "obj":"https://example.com/Person"}
-          ],
-        "config": {
-          "entity types": [
-            { "id": "https://example.com/Person", "label": "Person" }
+      let(:expected_format) do
+        {
+          "text": "[Elon Musk][Person] is a member of the PayPal Mafia.",
+          "denotations": [
+            { "span": { "begin": 40, "end": 52 }, "obj": "Organization" }
           ]
         }
-      } }
+      end
 
-      it 'use definitions as references' do
+      it "is not parsed as annotation" do
         is_expected.to eq(expected_format)
       end
     end
 
-    context 'when reference contains additional text after url' do
-      context 'when text is enclosed with quotation' do
+    context "when reference definitions do not have a blank line above" do
+      let(:source) do
+        <<~MD2
+          [Elon Musk][Person] is a member of the PayPal Mafia.
+          [Person]: https://example.com/Person
+        MD2
+      end
+      let(:expected_format) do
+        {
+          "text": "Elon Musk is a member of the PayPal Mafia.\n[Person]: https://example.com/Person",
+          "denotations": [
+            { "span": { "begin": 0, "end": 9 }, "obj": "Person" }
+          ]
+        }
+      end
+
+      it "does not use as references" do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context "when reference definitions have a blank line above" do
+      let(:source) do
+        <<~MD2
+          [Elon Musk][Person] is a member of the PayPal Mafia.
+
+          [Person]: https://example.com/Person
+        MD2
+      end
+      let(:expected_format) do
+        {
+          "text": "Elon Musk is a member of the PayPal Mafia.",
+          "denotations": [
+            { "span": { "begin": 0, "end": 9 }, "obj": "https://example.com/Person" }
+          ],
+          "config": {
+            "entity types": [
+              { "id": "https://example.com/Person", "label": "Person" }
+            ]
+          }
+        }
+      end
+
+      it "use definitions as references" do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context "when reference contains additional text after url" do
+      context "when text is enclosed with quotation" do
         let(:source) do
           <<~MD2
             [Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
@@ -115,26 +127,28 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
             [Organization]: https://example.com/Organization 'text'
           MD2
         end
-        let(:expected_format) { {
-          "text": "Elon Musk is a member of the PayPal Mafia.",
-          "denotations":[
-              {"span":{"begin": 0, "end": 9}, "obj":"https://example.com/Person"},
-              {"span":{"begin": 29, "end": 41}, "obj":"https://example.com/Organization"},
+        let(:expected_format) do
+          {
+            "text": "Elon Musk is a member of the PayPal Mafia.",
+            "denotations": [
+              { "span": { "begin": 0, "end": 9 }, "obj": "https://example.com/Person" },
+              { "span": { "begin": 29, "end": 41 }, "obj": "https://example.com/Organization" }
             ],
-          "config": {
-            "entity types": [
-              { "id": "https://example.com/Person", "label": "Person" },
-              { "id": "https://example.com/Organization", "label": "Organization" }
-            ]
+            "config": {
+              "entity types": [
+                { "id": "https://example.com/Person", "label": "Person" },
+                { "id": "https://example.com/Organization", "label": "Organization" }
+              ]
+            }
           }
-        } }
+        end
 
-        it 'parsed as reference link' do
+        it "parsed as reference link" do
           is_expected.to eq(expected_format)
         end
       end
 
-      context 'when text is not enclosed with quotation' do
+      context "when text is not enclosed with quotation" do
         let(:source) do
           <<~MD2
             [Elon Musk][Person] is a member of the PayPal Mafia.
@@ -142,20 +156,22 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
             [Person]: https://example.com/Person text
           MD2
         end
-        let(:expected_format) { {
-          "text": "Elon Musk is a member of the PayPal Mafia.\n\n[Person]: https://example.com/Person text",
-          "denotations":[
-              {"span":{"begin": 0, "end": 9}, "obj":"Person"}
+        let(:expected_format) do
+          {
+            "text": "Elon Musk is a member of the PayPal Mafia.\n\n[Person]: https://example.com/Person text",
+            "denotations": [
+              { "span": { "begin": 0, "end": 9 }, "obj": "Person" }
             ]
-        } }
+          }
+        end
 
-        it 'does not parse as reference link' do
+        it "does not parse as reference link" do
           is_expected.to eq(expected_format)
         end
       end
     end
 
-    context 'when text is written below the reference definition' do
+    context "when text is written below the reference definition" do
       let(:source) do
         <<~MD2
           [Elon Musk][Person] is a member of the PayPal Mafia.
@@ -164,24 +180,26 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
           hello
         MD2
       end
-      let(:expected_format) { {
-        "text": "Elon Musk is a member of the PayPal Mafia.\n\nhello",
-        "denotations":[
-            {"span":{"begin": 0, "end": 9}, "obj":"https://example.com/Person"}
+      let(:expected_format) do
+        {
+          "text": "Elon Musk is a member of the PayPal Mafia.\n\nhello",
+          "denotations": [
+            { "span": { "begin": 0, "end": 9 }, "obj": "https://example.com/Person" }
           ],
-        "config": {
-          "entity types": [
-            { "id": "https://example.com/Person", "label": "Person" }
-          ]
+          "config": {
+            "entity types": [
+              { "id": "https://example.com/Person", "label": "Person" }
+            ]
+          }
         }
-      } }
+      end
 
-      it 'parse as expected format' do
+      it "parse as expected format" do
         is_expected.to eq(expected_format)
       end
     end
 
-    context 'when reference id is duplicated' do
+    context "when reference id is duplicated" do
       let(:source) do
         <<~MD2
           [Elon Musk][Person] is a member of the PayPal Mafia.
@@ -190,65 +208,71 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
           [Person]: https://example.com/Organization
         MD2
       end
-      let(:expected_format) { {
-        "text": "Elon Musk is a member of the PayPal Mafia.",
-        "denotations":[
-            {"span":{"begin": 0, "end": 9}, "obj":"https://example.com/Person"},
+      let(:expected_format) do
+        {
+          "text": "Elon Musk is a member of the PayPal Mafia.",
+          "denotations": [
+            { "span": { "begin": 0, "end": 9 }, "obj": "https://example.com/Person" }
           ],
-        "config": {
-          "entity types": [
-            { "id": "https://example.com/Person", "label": "Person" }
-          ]
+          "config": {
+            "entity types": [
+              { "id": "https://example.com/Person", "label": "Person" }
+            ]
+          }
         }
-      } }
+      end
 
-      it 'use first defined id in priority' do
+      it "use first defined id in priority" do
         is_expected.to eq(expected_format)
       end
     end
 
-    context 'when reference label and id is same' do
+    context "when reference label and id is same" do
       let(:source) do
         <<~MD2
           [Elon Musk][Person] is a member of the PayPal Mafia.
 
           [Person]: Person
-          MD2
+        MD2
       end
-      let(:expected_format) { {
-        "text": "Elon Musk is a member of the PayPal Mafia.",
-        "denotations":[
-            {"span":{"begin": 0, "end": 9}, "obj":"Person"},
-          ],
-      } }
+      let(:expected_format) do
+        {
+          "text": "Elon Musk is a member of the PayPal Mafia.",
+          "denotations": [
+            { "span": { "begin": 0, "end": 9 }, "obj": "Person" }
+          ]
+        }
+      end
 
-      it 'is do not create config' do
+      it "is do not create config" do
         is_expected.to eq(expected_format)
       end
     end
 
-    context 'when consecutive newlines in source' do
+    context "when consecutive newlines in source" do
       let(:source) do
         <<~MD2
           [Elon Musk][Person] is a member of the PayPal Mafia.
 
 
           Elon Musk is a member of the PayPal Mafia.
-          MD2
+        MD2
       end
-      let(:expected_format) { {
-        "text": "Elon Musk is a member of the PayPal Mafia.\n\nElon Musk is a member of the PayPal Mafia.",
-        "denotations":[
-            {"span":{"begin": 0, "end": 9}, "obj":"Person"},
+      let(:expected_format) do
+        {
+          "text": "Elon Musk is a member of the PayPal Mafia.\n\nElon Musk is a member of the PayPal Mafia.",
+          "denotations": [
+            { "span": { "begin": 0, "end": 9 }, "obj": "Person" }
           ]
-      } }
+        }
+      end
 
-      it 'is parsed as single newline' do
+      it "is parsed as single newline" do
         is_expected.to eq(expected_format)
       end
     end
 
-    context 'when white spaces before reference definition' do
+    context "when white spaces before reference definition" do
       let(:source) do
         # Using <<- to create white spaces
         <<-MD2
@@ -258,21 +282,23 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
           [Organization]: https://example.com/Organization
         MD2
       end
-      let(:expected_format) { {
-        "text": "Elon Musk is a member of the PayPal Mafia.",
-        "denotations":[
-            {"span":{"begin": 0, "end": 9}, "obj":"https://example.com/Person"},
-            {"span":{"begin": 29, "end": 41}, "obj":"https://example.com/Organization"},
+      let(:expected_format) do
+        {
+          "text": "Elon Musk is a member of the PayPal Mafia.",
+          "denotations": [
+            { "span": { "begin": 0, "end": 9 }, "obj": "https://example.com/Person" },
+            { "span": { "begin": 29, "end": 41 }, "obj": "https://example.com/Organization" }
           ],
-        "config": {
-          "entity types": [
-            { "id": "https://example.com/Person", "label": "Person" },
-            { "id": "https://example.com/Organization", "label": "Organization" }
-          ]
+          "config": {
+            "entity types": [
+              { "id": "https://example.com/Person", "label": "Person" },
+              { "id": "https://example.com/Organization", "label": "Organization" }
+            ]
+          }
         }
-      } }
+      end
 
-      it 'parse as entity types with ignoring white spaces' do
+      it "parse as entity types with ignoring white spaces" do
         is_expected.to eq(expected_format)
       end
     end

--- a/spec/simple_inline_text_annotation/parser_spec.rb
+++ b/spec/simple_inline_text_annotation/parser_spec.rb
@@ -1,0 +1,280 @@
+require 'spec_helper'
+
+RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
+  describe '#parse' do
+    subject { SimpleInlineTextAnnotation.parse(source) }
+
+    context 'when source has annotation structure' do
+      let(:source) { '[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].' }
+      let(:expected_format) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.",
+        "denotations":[
+            {"span":{"begin": 0, "end": 9}, "obj":"Person"},
+            {"span":{"begin": 29, "end": 41}, "obj":"Organization"},
+          ]
+      } }
+
+      it 'parse as denotation' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context 'when surce has reference structure' do
+      let(:source) do
+        <<~MD2
+          [Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
+
+          [Person]: https://example.com/Person
+          [Organization]: https://example.com/Organization
+        MD2
+      end
+      let(:expected_format) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.",
+        "denotations":[
+            {"span":{"begin": 0, "end": 9}, "obj":"https://example.com/Person"},
+            {"span":{"begin": 29, "end": 41}, "obj":"https://example.com/Organization"},
+          ],
+        "config": {
+          "entity types": [
+            { "id": "https://example.com/Person", "label": "Person" },
+            { "id": "https://example.com/Organization", "label": "Organization" }
+          ]
+        }
+      } }
+
+      it 'parse as entity types and apply id to denotation obj' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context 'when source has metacharacter escape' do
+      let(:source) { '\[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].' }
+      let(:expected_format) { {
+        "text": "[Elon Musk][Person] is a member of the PayPal Mafia.",
+        "denotations":[
+            {"span":{"begin": 40, "end": 52}, "obj":"Organization"}
+          ]
+      } }
+
+      it 'is not parsed as annotation' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context 'when reference definitions do not have a blank line above' do
+      let(:source) do
+        <<~MD2
+          [Elon Musk][Person] is a member of the PayPal Mafia.
+          [Person]: https://example.com/Person
+        MD2
+      end
+      let(:expected_format) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.\n[Person]: https://example.com/Person",
+        "denotations":[
+            {"span":{"begin": 0, "end": 9}, "obj":"Person"}
+          ]
+      } }
+
+      it 'does not use as references' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context 'when reference definitions have a blank line above' do
+      let(:source) do
+        <<~MD2
+          [Elon Musk][Person] is a member of the PayPal Mafia.
+
+          [Person]: https://example.com/Person
+        MD2
+      end
+      let(:expected_format) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.",
+        "denotations":[
+            {"span":{"begin": 0, "end": 9}, "obj":"https://example.com/Person"}
+          ],
+        "config": {
+          "entity types": [
+            { "id": "https://example.com/Person", "label": "Person" }
+          ]
+        }
+      } }
+
+      it 'use definitions as references' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context 'when reference contains additional text after url' do
+      context 'when text is enclosed with quotation' do
+        let(:source) do
+          <<~MD2
+            [Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
+
+            [Person]: https://example.com/Person "text"
+            [Organization]: https://example.com/Organization 'text'
+          MD2
+        end
+        let(:expected_format) { {
+          "text": "Elon Musk is a member of the PayPal Mafia.",
+          "denotations":[
+              {"span":{"begin": 0, "end": 9}, "obj":"https://example.com/Person"},
+              {"span":{"begin": 29, "end": 41}, "obj":"https://example.com/Organization"},
+            ],
+          "config": {
+            "entity types": [
+              { "id": "https://example.com/Person", "label": "Person" },
+              { "id": "https://example.com/Organization", "label": "Organization" }
+            ]
+          }
+        } }
+
+        it 'parsed as reference link' do
+          is_expected.to eq(expected_format)
+        end
+      end
+
+      context 'when text is not enclosed with quotation' do
+        let(:source) do
+          <<~MD2
+            [Elon Musk][Person] is a member of the PayPal Mafia.
+
+            [Person]: https://example.com/Person text
+          MD2
+        end
+        let(:expected_format) { {
+          "text": "Elon Musk is a member of the PayPal Mafia.\n\n[Person]: https://example.com/Person text",
+          "denotations":[
+              {"span":{"begin": 0, "end": 9}, "obj":"Person"}
+            ]
+        } }
+
+        it 'does not parse as reference link' do
+          is_expected.to eq(expected_format)
+        end
+      end
+    end
+
+    context 'when text is written below the reference definition' do
+      let(:source) do
+        <<~MD2
+          [Elon Musk][Person] is a member of the PayPal Mafia.
+
+          [Person]: https://example.com/Person
+          hello
+        MD2
+      end
+      let(:expected_format) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.\n\nhello",
+        "denotations":[
+            {"span":{"begin": 0, "end": 9}, "obj":"https://example.com/Person"}
+          ],
+        "config": {
+          "entity types": [
+            { "id": "https://example.com/Person", "label": "Person" }
+          ]
+        }
+      } }
+
+      it 'parse as expected format' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context 'when reference id is duplicated' do
+      let(:source) do
+        <<~MD2
+          [Elon Musk][Person] is a member of the PayPal Mafia.
+
+          [Person]: https://example.com/Person
+          [Person]: https://example.com/Organization
+        MD2
+      end
+      let(:expected_format) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.",
+        "denotations":[
+            {"span":{"begin": 0, "end": 9}, "obj":"https://example.com/Person"},
+          ],
+        "config": {
+          "entity types": [
+            { "id": "https://example.com/Person", "label": "Person" }
+          ]
+        }
+      } }
+
+      it 'use first defined id in priority' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context 'when reference label and id is same' do
+      let(:source) do
+        <<~MD2
+          [Elon Musk][Person] is a member of the PayPal Mafia.
+
+          [Person]: Person
+          MD2
+      end
+      let(:expected_format) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.",
+        "denotations":[
+            {"span":{"begin": 0, "end": 9}, "obj":"Person"},
+          ],
+      } }
+
+      it 'is do not create config' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context 'when consecutive newlines in source' do
+      let(:source) do
+        <<~MD2
+          [Elon Musk][Person] is a member of the PayPal Mafia.
+
+
+          Elon Musk is a member of the PayPal Mafia.
+          MD2
+      end
+      let(:expected_format) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.\n\nElon Musk is a member of the PayPal Mafia.",
+        "denotations":[
+            {"span":{"begin": 0, "end": 9}, "obj":"Person"},
+          ]
+      } }
+
+      it 'is parsed as single newline' do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context 'when white spaces before reference definition' do
+      let(:source) do
+        # Using <<- to create white spaces
+        <<-MD2
+          [Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
+
+          [Person]: https://example.com/Person
+          [Organization]: https://example.com/Organization
+        MD2
+      end
+      let(:expected_format) { {
+        "text": "Elon Musk is a member of the PayPal Mafia.",
+        "denotations":[
+            {"span":{"begin": 0, "end": 9}, "obj":"https://example.com/Person"},
+            {"span":{"begin": 29, "end": 41}, "obj":"https://example.com/Organization"},
+          ],
+        "config": {
+          "entity types": [
+            { "id": "https://example.com/Person", "label": "Person" },
+            { "id": "https://example.com/Organization", "label": "Organization" }
+          ]
+        }
+      } }
+
+      it 'parse as entity types with ignoring white spaces' do
+        is_expected.to eq(expected_format)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 関連issue
close #3 

## 概要
https://github.com/pubannotation/pubannotation/tree/master/spec/models/simple_inline_text_annotation
以上のディレクトリからspecファイル2つを引っ張ってきました。
また、spec配下のディレクトリで`Layout/LineLength`の警告が出ないように`.rubocop.yml`を修正しました。

## 動作確認
25件全てのrspecがクリアすることをローカルで確認しています。
<img width="694" alt="スクリーンショット 2025-04-03 11 09 00" src="https://github.com/user-attachments/assets/3c8cf020-1fdc-4ded-be4c-773a94561a46" />

