### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,80 @@
 # SimpleInlineTextAnnotation
 
-TODO: Delete this and the text below, and describe your gem
-
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/simple_inline_text_annotation`. To experiment with that code, run `bin/console` for an interactive prompt.
+SimpleInlineTextAnnotation is a Ruby gem designed for working with inline text annotations. It allows you to parse and generate annotated text in a structured and efficient way.
 
 ## Installation
 
-TODO: Replace `UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG` with your gem name right after releasing it to RubyGems.org. Please do not do it earlier due to security reasons. Alternatively, replace this section with instructions to install your gem from git if you don't plan to release to RubyGems.org.
+To use this gem in a Rails application, add the following line to your application's `Gemfile`:
 
-Install the gem and add to the application's Gemfile by executing:
-
-```bash
-bundle add UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG
+```ruby
+gem 'simple_inline_text_annotation', github: 'Tamada-Arino/simple-inline-text-annotation'
 ```
 
-If bundler is not being used to manage dependencies, install the gem by executing:
+Then, run the following command to install the gem:
 
 ```bash
-gem install UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG
+bundle install
 ```
 
 ## Usage
 
-TODO: Write usage instructions here
+The `SimpleInlineTextAnnotation` gem provides two main methods: `parse` and `generate`. These methods allow you to work with inline text annotations in a structured way.
 
-## Development
+### `parse` Method
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+The `parse` method takes a string with inline annotations and extracts structured information about the annotations, including the character positions and annotation types.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+#### Example
 
-## Contributing
+```ruby
+result = SimpleInlineTextAnnotation.parse('[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].')
+puts result
+# => {
+#      text: "Elon Musk is a member of the PayPal Mafia.",
+#      denotations: [
+#        {span: {begin: 0, end: 9}, obj: "Person"},
+#        {span: {begin: 29, end: 41}, obj: "Organization"}
+#      ]
+#    }
+```
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/simple_inline_text_annotation. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/[USERNAME]/simple_inline_text_annotation/blob/main/CODE_OF_CONDUCT.md).
+#### Explanation
 
-## License
+- The input string `[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].` contains two annotations:
+  1. `[Elon Musk][Person]`: The text `Elon Musk` is annotated as `Person`.
+  2. `[PayPal Mafia][Organization]`: The text `PayPal Mafia` is annotated as `Organization`.
 
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+- The method returns a hash with:
+  - `"text"`: The plain text without annotations.
+  - `"denotations"`: An array of hashes, where each hash contains:
+    - `"span"`: The character positions (`begin` and `end`) of the annotated text.
+    - `"obj"`: The annotation type.
 
-## Code of Conduct
+### `generate` Method
 
-Everyone interacting in the SimpleInlineTextAnnotation project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/simple_inline_text_annotation/blob/main/CODE_OF_CONDUCT.md).
+The `generate` method performs the reverse operation of `parse`. It takes a hash containing the plain text and its annotations, and generates a string with inline annotations.
+
+#### Example
+
+```ruby
+result = SimpleInlineTextAnnotation.generate({
+  "text" => "Elon Musk is a member of the PayPal Mafia.",
+  "denotations" => [
+    { "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+    { "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
+  ]
+})
+puts result
+# => "[Elon Musk][Person] is a member of the [PayPal Mafia][Organization]."
+```
+
+#### Explanation
+
+- The input hash contains:
+  - `"text"`: The plain text ("Elon Musk is a member of the PayPal Mafia.").
+  - `"denotations"`: An array of hashes, where each hash specifies:
+    - `"span"`: The character positions (`begin` and `end`) of the annotated text.
+    - `"obj"`: The annotation type.
+- The method generates a string where:
+  - The text specified in `"span"` is enclosed in square brackets `[]`.
+  - The annotation type specified in `"obj"` is added in a second set of square brackets `[]`.


### PR DESCRIPTION
## 関連issue
close #5 

## 概要
- README.mdを編集しました。
   - InstallationとUsageについて記述しました。
   - 不要と思われるセクションを削除しました。

## 動作確認
- pubannotatonのGemfileに、Installationに書かれている
```ruby
gem 'simple_inline_text_annotation', github: 'Tamada-Arino/simple-inline-text-annotation'
```
以上を記述後、`bundle install` を実行
エラーが出ることがなくgemのインストールが終了したことを確認しました。

<img width="854" alt="スクリーンショット 2025-04-04 11 02 53" src="https://github.com/user-attachments/assets/6729ee7f-abc4-4c65-816b-a526f36e3134" />

- pubannotationから既存のsimple_inline_text_annotation関連のmodelsディレクトリ配下のファイルを削除後、コンソールでUsageの例の記述を行うと期待通りの値が返ってくることを確認しました。

<img width="1157" alt="スクリーンショット 2025-04-04 11 07 17" src="https://github.com/user-attachments/assets/04958f04-9951-4e56-8305-df8279547a49" />
