### PR TITLE
Implement GitHub Actions workflow for automatic gem release on PR merge to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release Gem
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.2
+
+      - name: Build gem
+        run: gem build simple_inline_text_annotation.gemspec
+
+      - name: Publish to Rubygems
+        env:
+          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+        run: gem push simple_inline_text_annotation-*.gem

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,9 @@
 name: Release Gem
 
 on:
-  workflow_dispatch:
   push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+    tags:
+      - 'v*'
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,15 @@
 name: Release Gem
 
 on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
   pull_request:
-    types:
-      - closed
+    branches: [ main ]
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    name: Release to RubyGems
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ SimpleInlineTextAnnotation is a Ruby gem designed for working with inline text a
 To use this gem in a Rails application, add the following line to your application's `Gemfile`:
 
 ```ruby
-gem 'simple_inline_text_annotation', github: 'Tamada-Arino/simple-inline-text-annotation'
+gem 'simple_inline_text_annotation'
 ```
 
 Then, run the following command to install the gem:

--- a/simple_inline_text_annotation.gemspec
+++ b/simple_inline_text_annotation.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
 
   s.metadata["homepage_uri"] = s.homepage
   s.metadata["changelog_uri"] = "https://github.com/Tamada-Arino/simple-inline-text-annotation/blob/master/CHANGELOG.md"
+  s.metadata["rubygems_uri"] = "https://rubygems.org/gems/simple_inline_text_annotation"
 
   gemspec = File.basename(__FILE__)
   s.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|


### PR DESCRIPTION
## 関連issue
close #11

## 概要
- RubyGems.orgにgemを公開
   - README.mdのgemの参照元をgithubからRubyGemsに変更
   - gemspecにRubyGemsのURLを追加

- `.github/woekflows/release.yml`の作成
   - https://docs.github.com/ja/actions/use-cases-and-examples/building-and-testing/building-and-testing-ruby#publishing-gems ここを参考にしました
   - 動作確認はこのPRのマージ時？


- このリポジトリにRubyGems.orgのAPIキーを設定
   - `RUBYGEMS_API_KEY`
   - https://docs.github.com/ja/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions を参考にしました

## 動作確認
- pubannotationのGemfileの`simple_inline_text_annotation`の記述を以下に変更(githubの参照元を削除)
```ruby
gem 'simple_inline_text_annotation'
```
- `bundle install`を実行、エラーが出ないことと`simple_inline_text_annotation`gemの参照元がRubyGems.orgになっていることを確認

- `.github/woekflows/release.yml`の動作確認はまだです
