### PR TITLE
Fix GitHub workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,27 +8,7 @@ on:
   pull_request:
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    name: Ruby ${{ matrix.ruby }}
-    strategy:
-      matrix:
-        ruby:
-          - '3.4.2'
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-
-      - name: Install dependencies
-        run: bundle install
-
-      - name: Run RuboCop
-        run: bundle exec rubocop
-
-      - name: Run RSpec
-        run: bundle exec rspec
+  test:
+    uses: ./.github/workflows/test.yml
+    with:
+      ruby-version: '3.4.2'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,13 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+      - name: Run Tests
+        uses: ./.github/workflows/test.yml
         with:
-          ruby-version: 3.4.2
+          ruby-version: '3.4.2'
 
       - name: Build gem
         run: gem build simple_inline_text_annotation.gemspec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test Workflow
+
+on:
+  workflow_call: # 他のワークフローから呼び出し可能にする
+    inputs:
+      ruby-version:
+        description: 'Ruby version to use'
+        required: true
+        type: string
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Ruby ${{ inputs.ruby-version }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ inputs.ruby-version }}
+          bundler-cache: true
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Run RuboCop
+        run: bundle exec rubocop
+
+      - name: Run RSpec
+        run: bundle exec rspec


### PR DESCRIPTION
## 概要
リリース時にテストステップを追加
rubocopとrspecを実行する`test.yml`を作成
PRとリリース時それぞれで`test.yml`が実行できるようにしました。

## 動作確認

- このPRでRubocopとRSpecが実行されていることを確認 → [Details](https://github.com/Tamada-Arino/simple-inline-text-annotation/actions/runs/14302404395/job/40079015761)
- リリース時は確認できていません