### PR TITLE
Add parser method with Object output and corresponding tests

### DIFF
--- a/js/__tests__/parser.test.mjs
+++ b/js/__tests__/parser.test.mjs
@@ -1,0 +1,197 @@
+import SimpleInlineTextAnnotation from '../src/index.mjs';
+
+describe('SimpleInlineTextAnnotation.parse', () => {
+  test('should parse as denotation when source has annotation structure', () => {
+    const source = "[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].";
+    const expected = JSON.stringify({
+      text: "Elon Musk is a member of the PayPal Mafia.",
+      denotations: [
+        { span: { begin: 0, end: 9 }, obj: "Person" },
+        { span: { begin: 29, end: 41 }, obj: "Organization" }
+      ]
+    });
+    expect(SimpleInlineTextAnnotation.parse(source)).toBe(expected);
+  });
+
+  test('should parse as entity types and apply id to denotation obj when source has reference structure', () => {
+    const source = `[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
+
+[Person]: https://example.com/Person
+[Organization]: https://example.com/Organization`;
+    const expected = JSON.stringify({
+      text: "Elon Musk is a member of the PayPal Mafia.",
+      denotations: [
+        { span: { begin: 0, end: 9 }, obj: "https://example.com/Person" },
+        { span: { begin: 29, end: 41 }, obj: "https://example.com/Organization" }
+      ],
+      config: {
+        "entity types": [
+          { id: "https://example.com/Person", label: "Person" },
+          { id: "https://example.com/Organization", label: "Organization" }
+        ]
+      }
+    });
+    expect(SimpleInlineTextAnnotation.parse(source)).toBe(expected);
+  });
+
+  test('should not parse as annotation when source has metacharacter escape', () => {
+    const source = '\\[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].';
+    const expected = JSON.stringify({
+      text: "[Elon Musk][Person] is a member of the PayPal Mafia.",
+      denotations: [
+        { span: { begin: 40, end: 52 }, obj: "Organization" }
+      ]
+    });
+    expect(SimpleInlineTextAnnotation.parse(source)).toBe(expected);
+  });
+
+  test('should not use as references when reference definitions do not have a blank line above', () => {
+    const source = `[Elon Musk][Person] is a member of the PayPal Mafia.
+[Person]: https://example.com/Person`;
+    const expected = JSON.stringify({
+      text: "Elon Musk is a member of the PayPal Mafia.\n[Person]: https://example.com/Person",
+      denotations: [
+        { span: { begin: 0, end: 9 }, obj: "Person" }
+      ]
+    });
+    expect(SimpleInlineTextAnnotation.parse(source)).toBe(expected);
+  });
+
+  test('should use definitions as references when reference definitions have a blank line above', () => {
+    const source = `[Elon Musk][Person] is a member of the PayPal Mafia.
+
+[Person]: https://example.com/Person`;
+    const expected = JSON.stringify({
+      text: "Elon Musk is a member of the PayPal Mafia.",
+      denotations: [
+        { span: { begin: 0, end: 9 }, obj: "https://example.com/Person" }
+      ],
+      config: {
+        "entity types": [
+          { id: "https://example.com/Person", label: "Person" }
+        ]
+      }
+    });
+    expect(SimpleInlineTextAnnotation.parse(source)).toBe(expected);
+  });
+
+  test('should parse as reference link when reference contains additional text enclosed with quotation', () => {
+    const source = `[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
+
+[Person]: https://example.com/Person "text"
+[Organization]: https://example.com/Organization 'text'`;
+    const expected = JSON.stringify({
+      text: "Elon Musk is a member of the PayPal Mafia.",
+      denotations: [
+        { span: { begin: 0, end: 9 }, obj: "https://example.com/Person" },
+        { span: { begin: 29, end: 41 }, obj: "https://example.com/Organization" }
+      ],
+      config: {
+        "entity types": [
+          { id: "https://example.com/Person", label: "Person" },
+          { id: "https://example.com/Organization", label: "Organization" }
+        ]
+      }
+    });
+    expect(SimpleInlineTextAnnotation.parse(source)).toBe(expected);
+  });
+
+  test('should not parse as reference link when reference contains additional text not enclosed with quotation', () => {
+    const source = `[Elon Musk][Person] is a member of the PayPal Mafia.
+
+[Person]: https://example.com/Person text`;
+    const expected = JSON.stringify({
+      text: "Elon Musk is a member of the PayPal Mafia.\n\n[Person]: https://example.com/Person text",
+      denotations: [
+        { span: { begin: 0, end: 9 }, obj: "Person" }
+      ]
+    });
+    expect(SimpleInlineTextAnnotation.parse(source)).toBe(expected);
+  });
+
+  test('should parse as expected format when text is written below the reference definition', () => {
+    const source = `[Elon Musk][Person] is a member of the PayPal Mafia.
+
+[Person]: https://example.com/Person
+hello`;
+    const expected = JSON.stringify({
+      text: "Elon Musk is a member of the PayPal Mafia.\n\nhello",
+      denotations: [
+        { span: { begin: 0, end: 9 }, obj: "https://example.com/Person" }
+      ],
+      config: {
+        "entity types": [
+          { id: "https://example.com/Person", label: "Person" }
+        ]
+      }
+    });
+    expect(SimpleInlineTextAnnotation.parse(source)).toBe(expected);
+  });
+
+  test('should use first defined id in priority when reference id is duplicated', () => {
+    const source = `[Elon Musk][Person] is a member of the PayPal Mafia.
+
+[Person]: https://example.com/Person
+[Person]: https://example.com/Organization`;
+    const expected = JSON.stringify({
+      text: "Elon Musk is a member of the PayPal Mafia.",
+      denotations: [
+        { span: { begin: 0, end: 9 }, obj: "https://example.com/Person" }
+      ],
+      config: {
+        "entity types": [
+          { id: "https://example.com/Person", label: "Person" }
+        ]
+      }
+    });
+    expect(SimpleInlineTextAnnotation.parse(source)).toBe(expected);
+  });
+
+  test('should not create config when reference label and id are the same', () => {
+    const source = `[Elon Musk][Person] is a member of the PayPal Mafia.
+
+[Person]: Person`;
+    const expected = JSON.stringify({
+      text: "Elon Musk is a member of the PayPal Mafia.",
+      denotations: [
+        { span: { begin: 0, end: 9 }, obj: "Person" }
+      ]
+    });
+    expect(SimpleInlineTextAnnotation.parse(source)).toBe(expected);
+  });
+
+  test('should parse as single newline when consecutive newlines in source', () => {
+    const source = `[Elon Musk][Person] is a member of the PayPal Mafia.
+
+
+Elon Musk is a member of the PayPal Mafia.`;
+    const expected = JSON.stringify({
+      text: "Elon Musk is a member of the PayPal Mafia.\n\nElon Musk is a member of the PayPal Mafia.",
+      denotations: [
+        { span: { begin: 0, end: 9 }, obj: "Person" }
+      ]
+    });
+    expect(SimpleInlineTextAnnotation.parse(source)).toBe(expected);
+  });
+
+  test('should parse as entity types with ignoring white spaces before reference definition', () => {
+    const source = `  [Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
+
+  [Person]: https://example.com/Person
+  [Organization]: https://example.com/Organization`;
+    const expected = JSON.stringify({
+      text: "Elon Musk is a member of the PayPal Mafia.",
+      denotations: [
+        { span: { begin: 0, end: 9 }, obj: "https://example.com/Person" },
+        { span: { begin: 29, end: 41 }, obj: "https://example.com/Organization" }
+      ],
+      config: {
+        "entity types": [
+          { id: "https://example.com/Person", label: "Person" },
+          { id: "https://example.com/Organization", label: "Organization" }
+        ]
+      }
+    });
+    expect(SimpleInlineTextAnnotation.parse(source)).toBe(expected);
+  });
+});

--- a/js/__tests__/parser.test.mjs
+++ b/js/__tests__/parser.test.mjs
@@ -3,14 +3,14 @@ import SimpleInlineTextAnnotation from '../src/index.mjs';
 describe('SimpleInlineTextAnnotation.parse', () => {
   test('should parse as denotation when source has annotation structure', () => {
     const source = "[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].";
-    const expected = JSON.stringify({
+    const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.",
       denotations: [
         { span: { begin: 0, end: 9 }, obj: "Person" },
         { span: { begin: 29, end: 41 }, obj: "Organization" }
       ]
-    });
-    expect(SimpleInlineTextAnnotation.parse(source)).toBe(expected);
+    };
+    expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
 
   test('should parse as entity types and apply id to denotation obj when source has reference structure', () => {
@@ -18,7 +18,7 @@ describe('SimpleInlineTextAnnotation.parse', () => {
 
 [Person]: https://example.com/Person
 [Organization]: https://example.com/Organization`;
-    const expected = JSON.stringify({
+    const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.",
       denotations: [
         { span: { begin: 0, end: 9 }, obj: "https://example.com/Person" },
@@ -30,38 +30,38 @@ describe('SimpleInlineTextAnnotation.parse', () => {
           { id: "https://example.com/Organization", label: "Organization" }
         ]
       }
-    });
-    expect(SimpleInlineTextAnnotation.parse(source)).toBe(expected);
+    };
+    expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
 
   test('should not parse as annotation when source has metacharacter escape', () => {
     const source = '\\[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].';
-    const expected = JSON.stringify({
+    const expected = {
       text: "[Elon Musk][Person] is a member of the PayPal Mafia.",
       denotations: [
         { span: { begin: 40, end: 52 }, obj: "Organization" }
       ]
-    });
-    expect(SimpleInlineTextAnnotation.parse(source)).toBe(expected);
+    };
+    expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
 
   test('should not use as references when reference definitions do not have a blank line above', () => {
     const source = `[Elon Musk][Person] is a member of the PayPal Mafia.
 [Person]: https://example.com/Person`;
-    const expected = JSON.stringify({
+    const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.\n[Person]: https://example.com/Person",
       denotations: [
         { span: { begin: 0, end: 9 }, obj: "Person" }
       ]
-    });
-    expect(SimpleInlineTextAnnotation.parse(source)).toBe(expected);
+    };
+    expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
 
   test('should use definitions as references when reference definitions have a blank line above', () => {
     const source = `[Elon Musk][Person] is a member of the PayPal Mafia.
 
 [Person]: https://example.com/Person`;
-    const expected = JSON.stringify({
+    const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.",
       denotations: [
         { span: { begin: 0, end: 9 }, obj: "https://example.com/Person" }
@@ -71,8 +71,8 @@ describe('SimpleInlineTextAnnotation.parse', () => {
           { id: "https://example.com/Person", label: "Person" }
         ]
       }
-    });
-    expect(SimpleInlineTextAnnotation.parse(source)).toBe(expected);
+    };
+    expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
 
   test('should parse as reference link when reference contains additional text enclosed with quotation', () => {
@@ -80,7 +80,7 @@ describe('SimpleInlineTextAnnotation.parse', () => {
 
 [Person]: https://example.com/Person "text"
 [Organization]: https://example.com/Organization 'text'`;
-    const expected = JSON.stringify({
+    const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.",
       denotations: [
         { span: { begin: 0, end: 9 }, obj: "https://example.com/Person" },
@@ -92,21 +92,21 @@ describe('SimpleInlineTextAnnotation.parse', () => {
           { id: "https://example.com/Organization", label: "Organization" }
         ]
       }
-    });
-    expect(SimpleInlineTextAnnotation.parse(source)).toBe(expected);
+    };
+    expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
 
   test('should not parse as reference link when reference contains additional text not enclosed with quotation', () => {
     const source = `[Elon Musk][Person] is a member of the PayPal Mafia.
 
 [Person]: https://example.com/Person text`;
-    const expected = JSON.stringify({
+    const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.\n\n[Person]: https://example.com/Person text",
       denotations: [
         { span: { begin: 0, end: 9 }, obj: "Person" }
       ]
-    });
-    expect(SimpleInlineTextAnnotation.parse(source)).toBe(expected);
+    };
+    expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
 
   test('should parse as expected format when text is written below the reference definition', () => {
@@ -114,7 +114,7 @@ describe('SimpleInlineTextAnnotation.parse', () => {
 
 [Person]: https://example.com/Person
 hello`;
-    const expected = JSON.stringify({
+    const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.\n\nhello",
       denotations: [
         { span: { begin: 0, end: 9 }, obj: "https://example.com/Person" }
@@ -124,8 +124,8 @@ hello`;
           { id: "https://example.com/Person", label: "Person" }
         ]
       }
-    });
-    expect(SimpleInlineTextAnnotation.parse(source)).toBe(expected);
+    };
+    expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
 
   test('should use first defined id in priority when reference id is duplicated', () => {
@@ -133,7 +133,7 @@ hello`;
 
 [Person]: https://example.com/Person
 [Person]: https://example.com/Organization`;
-    const expected = JSON.stringify({
+    const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.",
       denotations: [
         { span: { begin: 0, end: 9 }, obj: "https://example.com/Person" }
@@ -143,21 +143,21 @@ hello`;
           { id: "https://example.com/Person", label: "Person" }
         ]
       }
-    });
-    expect(SimpleInlineTextAnnotation.parse(source)).toBe(expected);
+    };
+    expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
 
   test('should not create config when reference label and id are the same', () => {
     const source = `[Elon Musk][Person] is a member of the PayPal Mafia.
 
 [Person]: Person`;
-    const expected = JSON.stringify({
+    const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.",
       denotations: [
         { span: { begin: 0, end: 9 }, obj: "Person" }
       ]
-    });
-    expect(SimpleInlineTextAnnotation.parse(source)).toBe(expected);
+    };
+    expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
 
   test('should parse as single newline when consecutive newlines in source', () => {
@@ -165,13 +165,13 @@ hello`;
 
 
 Elon Musk is a member of the PayPal Mafia.`;
-    const expected = JSON.stringify({
+    const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.\n\nElon Musk is a member of the PayPal Mafia.",
       denotations: [
         { span: { begin: 0, end: 9 }, obj: "Person" }
       ]
-    });
-    expect(SimpleInlineTextAnnotation.parse(source)).toBe(expected);
+    };
+    expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
 
   test('should parse as entity types with ignoring white spaces before reference definition', () => {
@@ -179,7 +179,7 @@ Elon Musk is a member of the PayPal Mafia.`;
 
   [Person]: https://example.com/Person
   [Organization]: https://example.com/Organization`;
-    const expected = JSON.stringify({
+    const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.",
       denotations: [
         { span: { begin: 0, end: 9 }, obj: "https://example.com/Person" },
@@ -191,7 +191,7 @@ Elon Musk is a member of the PayPal Mafia.`;
           { id: "https://example.com/Organization", label: "Organization" }
         ]
       }
-    });
-    expect(SimpleInlineTextAnnotation.parse(source)).toBe(expected);
+    };
+    expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
 });

--- a/js/src/entity_type_collection.mjs
+++ b/js/src/entity_type_collection.mjs
@@ -14,7 +14,7 @@ class EntityTypeCollection {
    * @returns {string|undefined} The ID associated with the label, or undefined if not found
    */
   get(label) {
-    return this.#entityTypes[label];
+    return this.#getEntityTypes[label];
   }
 
   /**
@@ -28,7 +28,7 @@ class EntityTypeCollection {
    * ]
    */
   get config() {
-    return Object.entries(this.#entityTypes).map(([label, id]) => ({
+    return Object.entries(this.#getEntityTypes).map(([label, id]) => ({
       id,
       label,
     }));
@@ -46,7 +46,7 @@ class EntityTypeCollection {
    *   "Organization": "https://example.com/Organization"
    * }
    */
-  get #entityTypes() {
+  get #getEntityTypes() {
     if (!this._entityTypes) {
       this._entityTypes = this.#readEntitiesFromSource();
     }

--- a/js/src/entity_type_collection.mjs
+++ b/js/src/entity_type_collection.mjs
@@ -7,6 +7,12 @@ class EntityTypeCollection {
     this._entityTypes = null;
   }
 
+  /**
+   * Retrieves the ID for the given entity type label.
+   *
+   * @param {string} label - The entity type label to look up
+   * @returns {string|undefined} The ID associated with the label, or undefined if not found
+   */
   get(label) {
     return this.#entityTypes[label];
   }

--- a/js/src/entity_type_collection.mjs
+++ b/js/src/entity_type_collection.mjs
@@ -16,7 +16,7 @@ class EntityTypeCollection {
    * @returns {string|undefined} The ID associated with the label, or undefined if not found
    */
   get(label) {
-    return this.#getEntityTypes[label];
+    return this.#cachedEntityTypes[label];
   }
 
   /**
@@ -30,7 +30,7 @@ class EntityTypeCollection {
    * ]
    */
   get config() {
-    return Object.entries(this.#getEntityTypes).map(([label, id]) => ({
+    return Object.entries(this.#cachedEntityTypes).map(([label, id]) => ({
       id,
       label,
     }));
@@ -48,7 +48,7 @@ class EntityTypeCollection {
    *   "Organization": "https://example.com/Organization"
    * }
    */
-  get #getEntityTypes() {
+  get #cachedEntityTypes() {
     if (!this.#entityTypes) {
       this.#entityTypes = this.#readEntitiesFromSource();
     }

--- a/js/src/entity_type_collection.mjs
+++ b/js/src/entity_type_collection.mjs
@@ -1,0 +1,87 @@
+const ENTITY_TYPE_PATTERN = /^\s*\[([^\]]+)\]:\s+(\S+)(?:\s+(?:"[^"]*"|'[^']*'))?\s*$/;
+const ENTITY_TYPE_BLOCK_PATTERN = new RegExp(`(?:\\A|\\n\\s*\\n)((?:${ENTITY_TYPE_PATTERN.source}(?:\\n|$))+)`, 'gm');
+
+class EntityTypeCollection {
+  constructor(source) {
+    this.source = source;
+    this._entityTypes = null;
+  }
+
+  get(label) {
+    return this.entityTypes()[label];
+  }
+
+  /**
+   * Converts the entity types into an array of objects.
+   *
+   * @returns {Array<Object>} An array of objects representing entity types.
+   * Example:
+   * [
+   *   { id: "https://example.com/Person", label: "Person" },
+   *   { id: "https://example.com/Organization", label: "Organization" }
+   * ]
+   */
+  toConfig() {
+    return Object.entries(this.entityTypes()).map(([label, id]) => ({
+      id,
+      label,
+    }));
+  }
+
+  any() {
+    return Object.keys(this.entityTypes()).length > 0;
+  }
+
+  /**
+   * Returns a hash where the keys are labels and the values are IDs.
+   * If the entity types have not been read yet, it reads them from the source
+   * and caches the result for future calls.
+   *
+   * @returns {Object} A hash structured with labels as keys and IDs as values.
+   * Example:
+   * {
+   *   "Person": "https://example.com/Person",
+   *   "Organization": "https://example.com/Organization"
+   * }
+   */
+  entityTypes() {
+    if (!this._entityTypes) {
+      this._entityTypes = this.readEntitiesFromSource();
+    }
+    return this._entityTypes;
+  }
+
+  readEntitiesFromSource() {
+    const entityTypes = {};
+
+    const matches = Array.from(this.source.matchAll(ENTITY_TYPE_BLOCK_PATTERN));
+    for (const match of matches) {
+      this.processEntityBlock(match, entityTypes);
+    }
+
+    return entityTypes;
+  }
+
+  processEntityBlock(entityBlock, entityTypes) {
+    const blockContent = entityBlock[0];
+    const lines = blockContent.split('\n');
+
+    for (const line of lines) {
+      this.processEntityLine(line, entityTypes);
+    }
+  }
+
+  processEntityLine(line, entityTypes) {
+    const match = line.trim().match(ENTITY_TYPE_PATTERN);
+    if (!match) return;
+
+    const [_, label, id] = match;
+    if (label === id) return; // Skip if label and id are the same.
+
+    if (!entityTypes[label]) {
+      entityTypes[label] = id; // Avoid overwriting existing label.
+    }
+  }
+}
+
+export default EntityTypeCollection;

--- a/js/src/entity_type_collection.mjs
+++ b/js/src/entity_type_collection.mjs
@@ -2,9 +2,11 @@ const ENTITY_TYPE_PATTERN = /^\s*\[([^\]]+)\]:\s+(\S+)(?:\s+(?:"[^"]*"|'[^']*'))
 const ENTITY_TYPE_BLOCK_PATTERN = new RegExp(`(?:\\A|\\n\\s*\\n)((?:${ENTITY_TYPE_PATTERN.source}(?:\\n|$))+)`, 'gm');
 
 class EntityTypeCollection {
+  #source;
+  #entityTypes = null;
+
   constructor(source) {
-    this.source = source;
-    this._entityTypes = null;
+    this.#source = source;
   }
 
   /**
@@ -47,16 +49,16 @@ class EntityTypeCollection {
    * }
    */
   get #getEntityTypes() {
-    if (!this._entityTypes) {
-      this._entityTypes = this.#readEntitiesFromSource();
+    if (!this.#entityTypes) {
+      this.#entityTypes = this.#readEntitiesFromSource();
     }
-    return this._entityTypes;
+    return this.#entityTypes;
   }
 
   #readEntitiesFromSource() {
     const entityTypes = {};
 
-    const matches = Array.from(this.source.matchAll(ENTITY_TYPE_BLOCK_PATTERN));
+    const matches = Array.from(this.#source.matchAll(ENTITY_TYPE_BLOCK_PATTERN));
     for (const match of matches) {
       this.#processEntityBlock(match, entityTypes);
     }

--- a/js/src/entity_type_collection.mjs
+++ b/js/src/entity_type_collection.mjs
@@ -8,7 +8,7 @@ class EntityTypeCollection {
   }
 
   get(label) {
-    return this.entityTypes()[label];
+    return this.#entityTypes[label];
   }
 
   /**
@@ -21,15 +21,11 @@ class EntityTypeCollection {
    *   { id: "https://example.com/Organization", label: "Organization" }
    * ]
    */
-  toConfig() {
-    return Object.entries(this.entityTypes()).map(([label, id]) => ({
+  get config() {
+    return Object.entries(this.#entityTypes).map(([label, id]) => ({
       id,
       label,
     }));
-  }
-
-  any() {
-    return Object.keys(this.entityTypes()).length > 0;
   }
 
   /**
@@ -44,34 +40,34 @@ class EntityTypeCollection {
    *   "Organization": "https://example.com/Organization"
    * }
    */
-  entityTypes() {
+  get #entityTypes() {
     if (!this._entityTypes) {
-      this._entityTypes = this.readEntitiesFromSource();
+      this._entityTypes = this.#readEntitiesFromSource();
     }
     return this._entityTypes;
   }
 
-  readEntitiesFromSource() {
+  #readEntitiesFromSource() {
     const entityTypes = {};
 
     const matches = Array.from(this.source.matchAll(ENTITY_TYPE_BLOCK_PATTERN));
     for (const match of matches) {
-      this.processEntityBlock(match, entityTypes);
+      this.#processEntityBlock(match, entityTypes);
     }
 
     return entityTypes;
   }
 
-  processEntityBlock(entityBlock, entityTypes) {
+  #processEntityBlock(entityBlock, entityTypes) {
     const blockContent = entityBlock[0];
     const lines = blockContent.split('\n');
 
     for (const line of lines) {
-      this.processEntityLine(line, entityTypes);
+      this.#processEntityLine(line, entityTypes);
     }
   }
 
-  processEntityLine(line, entityTypes) {
+  #processEntityLine(line, entityTypes) {
     const match = line.trim().match(ENTITY_TYPE_PATTERN);
     if (!match) return;
 

--- a/js/src/index.mjs
+++ b/js/src/index.mjs
@@ -14,7 +14,7 @@ class SimpleInlineTextAnnotation {
     const parser = new Parser(source);
     const result = parser.parse().#toObject();
 
-    return JSON.stringify(result);
+    return result;
   }
 
   static generate(source) {

--- a/js/src/index.mjs
+++ b/js/src/index.mjs
@@ -53,7 +53,7 @@ class SimpleInlineTextAnnotation {
     if (!this.entityTypeCollection || this.entityTypeCollection.length === 0) {
       return null;
     }
-    return { 'entity types': this.entityTypeCollection.toConfig() };
+    return { 'entity types': this.entityTypeCollection.config };
   }
 }
 

--- a/js/src/index.mjs
+++ b/js/src/index.mjs
@@ -1,4 +1,5 @@
 import Generator from './generator.mjs';
+import Parser from './parser.mjs';
 
 const ESCAPE_PATTERN = /\\(?=\[[^\]]+\]\[[^\]]+\])/;
 

--- a/js/src/parser.mjs
+++ b/js/src/parser.mjs
@@ -1,0 +1,63 @@
+import EntityTypeCollection from './entity_type_collection.mjs';
+import Denotation from './denotation.mjs';
+import SimpleInlineTextAnnotation from './index.mjs';
+
+const ENTITY_TYPE_PATTERN = /^\s*\[([^\]]+)\]:\s+(\S+)(?:\s+(?:"[^"]*"|'[^']*'))?\s*$/;
+const ENTITY_TYPE_BLOCK_PATTERN = new RegExp(`(?:\\A|\\n\\s*\\n)((?:${ENTITY_TYPE_PATTERN.source}(?:\\n|$))+)`, 'gm');
+const DENOTATION_PATTERN = /(?<!\\)\[([^\[]+?)\]\[([^\]]+?)\]/;
+
+class Parser {
+  constructor(source) {
+    this.source = source;
+    this.denotations = [];
+    this.entityTypeCollection = new EntityTypeCollection(source);
+  }
+
+  parse() {
+    let fullText = this.sourceWithoutReferences();
+
+    fullText = this.processDenotations(fullText);
+
+    return new SimpleInlineTextAnnotation(
+      fullText,
+      this.denotations,
+      this.entityTypeCollection
+    );
+  }
+
+  // Remove references from the source.
+  sourceWithoutReferences() {
+    return this.source
+      .replace(ENTITY_TYPE_BLOCK_PATTERN, (block) =>
+        block.startsWith('\n\n') ? '\n\n' : ''
+      )
+      .trim();
+  }
+
+  getObjFor(label) {
+    return this.entityTypeCollection.get(label) || label;
+  }
+
+  processDenotations(fullText) {
+    const regex = new RegExp(DENOTATION_PATTERN, 'g');
+    let match;
+
+    while ((match = regex.exec(fullText)) !== null) {
+      const targetText = match[1];
+      const label = match[2];
+
+      const beginPos = match.index;
+      const endPos = beginPos + targetText.length;
+
+      const obj = this.getObjFor(label);
+
+      this.denotations.push(new Denotation(beginPos, endPos, obj));
+
+      fullText = fullText.slice(0, match.index) + targetText + fullText.slice(match.index + match[0].length);
+    }
+
+    return fullText;
+  }
+}
+
+export default Parser;

--- a/js/src/parser.mjs
+++ b/js/src/parser.mjs
@@ -7,10 +7,14 @@ const ENTITY_TYPE_BLOCK_PATTERN = new RegExp(`(?:\\A|\\n\\s*\\n)((?:${ENTITY_TYP
 const DENOTATION_PATTERN = /(?<!\\)\[([^\[]+?)\]\[([^\]]+?)\]/;
 
 class Parser {
+  #source;
+  #denotations;
+  #entityTypeCollection;
+
   constructor(source) {
-    this.source = source;
-    this.denotations = [];
-    this.entityTypeCollection = new EntityTypeCollection(source);
+    this.#source = source;
+    this.#denotations = [];
+    this.#entityTypeCollection = new EntityTypeCollection(source);
   }
 
   parse() {
@@ -20,14 +24,14 @@ class Parser {
 
     return new SimpleInlineTextAnnotation(
       fullText,
-      this.denotations,
-      this.entityTypeCollection
+      this.#denotations,
+      this.#entityTypeCollection
     );
   }
 
   // Remove references from the source.
   #sourceWithoutReferences() {
-    return this.source
+    return this.#source
       .replace(ENTITY_TYPE_BLOCK_PATTERN, (block) =>
         block.startsWith('\n\n') ? '\n\n' : ''
       )
@@ -35,7 +39,7 @@ class Parser {
   }
 
   #getObjFor(label) {
-    return this.entityTypeCollection.get(label) || label;
+    return this.#entityTypeCollection.get(label) || label;
   }
 
   #processDenotations(fullText) {
@@ -51,7 +55,7 @@ class Parser {
 
       const obj = this.#getObjFor(label);
 
-      this.denotations.push(new Denotation(beginPos, endPos, obj));
+      this.#denotations.push(new Denotation(beginPos, endPos, obj));
 
       fullText = fullText.slice(0, match.index) + targetText + fullText.slice(match.index + match[0].length);
     }

--- a/js/src/parser.mjs
+++ b/js/src/parser.mjs
@@ -14,9 +14,9 @@ class Parser {
   }
 
   parse() {
-    let fullText = this.sourceWithoutReferences();
+    let fullText = this.#sourceWithoutReferences();
 
-    fullText = this.processDenotations(fullText);
+    fullText = this.#processDenotations(fullText);
 
     return new SimpleInlineTextAnnotation(
       fullText,
@@ -26,7 +26,7 @@ class Parser {
   }
 
   // Remove references from the source.
-  sourceWithoutReferences() {
+  #sourceWithoutReferences() {
     return this.source
       .replace(ENTITY_TYPE_BLOCK_PATTERN, (block) =>
         block.startsWith('\n\n') ? '\n\n' : ''
@@ -34,11 +34,11 @@ class Parser {
       .trim();
   }
 
-  getObjFor(label) {
+  #getObjFor(label) {
     return this.entityTypeCollection.get(label) || label;
   }
 
-  processDenotations(fullText) {
+  #processDenotations(fullText) {
     const regex = new RegExp(DENOTATION_PATTERN, 'g');
     let match;
 
@@ -49,7 +49,7 @@ class Parser {
       const beginPos = match.index;
       const endPos = beginPos + targetText.length;
 
-      const obj = this.getObjFor(label);
+      const obj = this.#getObjFor(label);
 
       this.denotations.push(new Denotation(beginPos, endPos, obj));
 


### PR DESCRIPTION
## 関連issue
#14 

## 概要

- テキストを受け取ってObject形式で返すparserメソッドを作成しました。
- parserメソッドに関するテストファイルを作成しました。
   - 内容はparser_spec.rbと同じになっているはずです


## 動作確認
- 以下の動作確認用のファイルを作成して、期待通りの結果が得られることを確認しました。
```js
import SimpleInlineTextAnnotation from 'simple-inline-text-annotation';

const source = `[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].

[Person]: https://example.com/Person
[Organization]: https://example.com/Organization`;

const result = SimpleInlineTextAnnotation.parse(source);
console.log(JSON.stringify(result, null, 2));
```
<img width="570" alt="スクリーンショット 2025-04-14 11 08 54" src="https://github.com/user-attachments/assets/5706b382-f5d7-46e7-9b25-865c3aef29e4" />



 - `npm test`を実行して、25件全てのテストが通ることを確認しました。
 
<img width="775" alt="スクリーンショット 2025-04-11 13 58 28" src="https://github.com/user-attachments/assets/c0195364-6e4b-47fe-a705-42ee49d01415" />
