### PR TITLE
Reset denotations in parse method to prevent accumulation on multiple calls

### DIFF
--- a/js/__tests__/parser.test.mjs
+++ b/js/__tests__/parser.test.mjs
@@ -204,7 +204,6 @@ describe('Parser', () => {
 [Person]: https://example.com/Person
 [Organization]: https://example.com/Organization`;
 
-console.log("source");
     const parser = new Parser(source);
     parser.parse();
     const result = parser.parse().toObject();

--- a/js/__tests__/parser.test.mjs
+++ b/js/__tests__/parser.test.mjs
@@ -1,4 +1,5 @@
 import SimpleInlineTextAnnotation from '../src/index.mjs';
+import Parser from '../src/parser.mjs';
 
 describe('SimpleInlineTextAnnotation.parse', () => {
   test('should parse as denotation when source has annotation structure', () => {
@@ -193,5 +194,24 @@ Elon Musk is a member of the PayPal Mafia.`;
       }
     };
     expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
+  });
+});
+
+describe('Parser', () => {
+  test('should not accumulate denotations when parse is called multiple times', () => {
+    const source = `[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
+
+[Person]: https://example.com/Person
+[Organization]: https://example.com/Organization`;
+
+console.log("source");
+    const parser = new Parser(source);
+    parser.parse();
+    const result = parser.parse().toObject();
+
+    expect(result.denotations).toEqual([
+      { span: { begin: 0, end: 9 }, obj: "https://example.com/Person" },
+      { span: { begin: 29, end: 41 }, obj: "https://example.com/Organization" },
+    ]);
   });
 });

--- a/js/src/index.mjs
+++ b/js/src/index.mjs
@@ -12,7 +12,7 @@ class SimpleInlineTextAnnotation {
 
   static parse(source) {
     const parser = new Parser(source);
-    const result = parser.parse().#toObject();
+    const result = parser.parse().toObject();
 
     return result;
   }
@@ -22,7 +22,7 @@ class SimpleInlineTextAnnotation {
     return generator.generate();
   }
 
-  #toObject() {
+  toObject() {
     const result = {
       text: this.#formatText(this.text),
       denotations: this.denotations.map((d) => d.toObject()),

--- a/js/src/parser.mjs
+++ b/js/src/parser.mjs
@@ -13,11 +13,11 @@ class Parser {
 
   constructor(source) {
     this.#source = source;
-    this.#denotations = [];
     this.#entityTypeCollection = new EntityTypeCollection(source);
   }
 
   parse() {
+    this.#denotations = [];
     let fullText = this.#sourceWithoutReferences();
 
     fullText = this.#processDenotations(fullText);

--- a/ruby/lib/simple_inline_text_annotation/parser.rb
+++ b/ruby/lib/simple_inline_text_annotation/parser.rb
@@ -11,11 +11,11 @@ class SimpleInlineTextAnnotation
 
     def initialize(source)
       @source = source.dup.freeze
-      @denotations = []
       @entity_type_collection = EntityTypeCollection.new(source)
     end
 
     def parse
+      @denotations = []
       full_text = source_without_references
 
       process_denotations(full_text)

--- a/ruby/spec/simple_inline_text_annotation/parser_spec.rb
+++ b/ruby/spec/simple_inline_text_annotation/parser_spec.rb
@@ -302,5 +302,34 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         is_expected.to eq(expected_format)
       end
     end
+
+    context "when parse is called multiple times" do
+      let(:source) do
+        <<~MD
+          [Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
+
+          [Person]: https://example.com/Person
+          [Organization]: https://example.com/Organization
+        MD
+      end
+
+      let(:expected_format) do
+        {
+          "text": "Elon Musk is a member of the PayPal Mafia.",
+          "denotations": [
+            { "span": { "begin": 0, "end": 9 }, "obj": "https://example.com/Person" },
+            { "span": { "begin": 29, "end": 41 }, "obj": "https://example.com/Organization" }
+          ]
+        }
+      end
+
+      it "does not accumulate denotations when parse is called multiple times" do
+        parser = SimpleInlineTextAnnotation::Parser.new(source)
+        parser.parse
+        result = parser.parse.to_h
+
+        expect(result[:denotations]).to eq(expected_format[:denotations])
+      end
+    end
   end
 end


### PR DESCRIPTION
## 関連issue
#14

## 概要
https://github.com/Tamada-Arino/simple-inline-text-annotation/pull/21#discussion_r2041463346
このコメントで指摘されているdenotationsがparseメソッドを呼び出すたびに累積される問題の対応を行いました。
- parseメソッドを呼び出した時にdenotationsを初期化するように修正しています。

## 動作確認
- 複数回parseを実行しても、denotationsが累積されないテストを実装しました → [Add test for Parser class](https://github.com/Tamada-Arino/simple-inline-text-annotation/pull/22/commits/bb3231cb0f71778d1b60d52627b0f984bb7fb8e2)
- 追加分のテストを含めた全てのテストが通ることを確認しました。
<img width="657" alt="スクリーンショット 2025-04-15 9 47 40" src="https://github.com/user-attachments/assets/79098308-b610-4097-8148-6ae64a314ef0" />
<img width="1077" alt="スクリーンショット 2025-04-15 10 18 37" src="https://github.com/user-attachments/assets/b92f34e1-4106-4312-96e0-829543ae5156" />
