### PR TITLE
Add comment for get method in entity_type_collection.rb

### DIFF
--- a/ruby/lib/simple_inline_text_annotation/entity_type_collection.rb
+++ b/ruby/lib/simple_inline_text_annotation/entity_type_collection.rb
@@ -6,6 +6,13 @@ class SimpleInlineTextAnnotation
       @source = source
     end
 
+    # get returns the entity type id for a given label.
+    # Example:
+    #   get("Person") => "https://example.com/Person"
+    #
+    # If the label is not found, it returns nil.
+    # Example:
+    #   get("NonExistentLabel") => nil
     def get(label)
       entity_types[label]
     end


### PR DESCRIPTION
## 関連issue
#14 

## 概要
https://github.com/Tamada-Arino/simple-inline-text-annotation/pull/21#discussion_r2038894144
このコメントの対応で、`entity_type_collection.rb`のgetメソッドに対してもコメントを追加しました。

```ruby
    # get returns the entity type id for a given label.
    # Example:
    #   get("Person") => "https://example.com/Person"
    #
    # If the label is not found, it returns nil.
    # Example:
    #   get("NonExistentLabel") => nil
    def get(label)
      entity_types[label]
    end
```

## 動作確認
なし