### PR TITLE
Make fields private in index.mjs

### DIFF
--- a/js/src/index.mjs
+++ b/js/src/index.mjs
@@ -4,10 +4,14 @@ import Parser from './parser.mjs';
 const ESCAPE_PATTERN = /\\(?=\[[^\]]+\]\[[^\]]+\])/;
 
 class SimpleInlineTextAnnotation {
+  #text;
+  #denotations;
+  #entityTypeCollection;
+
   constructor(text, denotations, entityTypeCollection) {
-    this.text = text;
-    this.denotations = denotations;
-    this.entityTypeCollection = entityTypeCollection;
+    this.#text = text;
+    this.#denotations = denotations;
+    this.#entityTypeCollection = entityTypeCollection;
   }
 
   static parse(source) {
@@ -24,8 +28,8 @@ class SimpleInlineTextAnnotation {
 
   toObject() {
     const result = {
-      text: this.#formatText(this.text),
-      denotations: this.denotations.map((d) => d.toObject()),
+      text: this.#formatText(this.#text),
+      denotations: this.#denotations.map((d) => d.toObject()),
     };
 
     const config = this.#config();
@@ -50,10 +54,10 @@ class SimpleInlineTextAnnotation {
   }
 
   #config() {
-    if (!this.entityTypeCollection || this.entityTypeCollection.length === 0) {
+    if (!this.#entityTypeCollection || this.#entityTypeCollection.length === 0) {
       return null;
     }
-    return { 'entity types': this.entityTypeCollection.config };
+    return { 'entity types': this.#entityTypeCollection.config };
   }
 }
 


### PR DESCRIPTION
## 関連issue
#14

## 概要
https://github.com/Tamada-Arino/simple-inline-text-annotation/pull/21#discussion_r2041458811
こちらのコメントでいただいていた、text, denotations, entityTypeCollectionのprivate化を行いました。

## 動作確認
既存のテストが全て通ることを確認しました。

<img width="1057" alt="スクリーンショット 2025-04-15 11 25 24" src="https://github.com/user-attachments/assets/7c364116-843b-41a1-b882-09ccf01799c6" />
