### PR TITLE
Make the parser method compatible with relation notation for ruby

### DIFF
--- a/ruby/lib/simple_inline_text_annotation.rb
+++ b/ruby/lib/simple_inline_text_annotation.rb
@@ -20,9 +20,10 @@ class SimpleInlineTextAnnotation
   # Example: \[This is a part of][original text]
   ESCAPE_PATTERN = /\\(?=\[[^\]]+\]\[[^\]]+\])/
 
-  def initialize(text, denotations, entity_type_collection)
+  def initialize(text, denotations, relations, entity_type_collection)
     @text = text
     @denotations = denotations
+    @relations = relations
     @entity_type_collection = entity_type_collection
   end
 
@@ -39,6 +40,7 @@ class SimpleInlineTextAnnotation
     {
       text: format_text(@text),
       denotations: @denotations.map(&:to_h),
+      relations: @relations&.map(&:to_h),
       config: config
     }.compact
   end

--- a/ruby/lib/simple_inline_text_annotation.rb
+++ b/ruby/lib/simple_inline_text_annotation.rb
@@ -40,7 +40,7 @@ class SimpleInlineTextAnnotation
     {
       text: format_text(@text),
       denotations: @denotations.map(&:to_h),
-      relations: @relations&.map(&:to_h),
+      relations: @relations.empty? ? nil : @relations,
       config: config
     }.compact
   end

--- a/ruby/lib/simple_inline_text_annotation/denotation.rb
+++ b/ruby/lib/simple_inline_text_annotation/denotation.rb
@@ -5,12 +5,13 @@ require_relative "generator_error"
 
 class SimpleInlineTextAnnotation
   class Denotation
-    attr_reader :begin_pos, :end_pos, :obj
+    attr_reader :begin_pos, :end_pos, :obj, :id
 
-    def initialize(begin_pos, end_pos, obj)
+    def initialize(begin_pos, end_pos, obj, id = nil)
       @begin_pos = begin_pos
       @end_pos = end_pos
       @obj = obj
+      @id = id
     end
 
     def span
@@ -18,7 +19,7 @@ class SimpleInlineTextAnnotation
     end
 
     def to_h
-      { span: span, obj: @obj }
+      { id: @id, span: span, obj: @obj }.compact
     end
 
     def nested_within?(other)

--- a/ruby/lib/simple_inline_text_annotation/parser.rb
+++ b/ruby/lib/simple_inline_text_annotation/parser.rb
@@ -24,7 +24,7 @@ class SimpleInlineTextAnnotation
       SimpleInlineTextAnnotation.new(
         full_text,
         @denotations,
-        @relations.empty? ? nil : @relations,
+        @relations,
         @entity_type_collection
       )
     end

--- a/ruby/lib/simple_inline_text_annotation/parser.rb
+++ b/ruby/lib/simple_inline_text_annotation/parser.rb
@@ -45,7 +45,7 @@ class SimpleInlineTextAnnotation
     def process_denotations(full_text)
       pos = 0
 
-      while match = DENOTATION_PATTERN.match(full_text, pos)
+      while (match = DENOTATION_PATTERN.match(full_text, pos))
         result = process_single_denotation(match, full_text)
         pos = result == :processed ? match.begin(0) + match[1].length : match.end(0)
       end
@@ -57,6 +57,13 @@ class SimpleInlineTextAnnotation
       end_pos = begin_pos + target_text.length
       annotations = match[2].split(", ")
 
+      return :skipped unless process_annotation_by_size(annotations, begin_pos, end_pos)
+
+      full_text[match.begin(0)...match.end(0)] = target_text
+      :processed
+    end
+
+    def process_annotation_by_size(annotations, begin_pos, end_pos)
       case annotations.size
       when 1
         process_single_annotation(begin_pos, end_pos, annotations[0])
@@ -64,12 +71,7 @@ class SimpleInlineTextAnnotation
         process_double_annotation(begin_pos, end_pos, annotations)
       when 4
         process_quadruple_annotation(begin_pos, end_pos, annotations)
-      else
-        return :skipped
       end
-
-      full_text[match.begin(0)...match.end(0)] = target_text
-      :processed
     end
 
     def process_single_annotation(begin_pos, end_pos, label)

--- a/ruby/lib/simple_inline_text_annotation/parser.rb
+++ b/ruby/lib/simple_inline_text_annotation/parser.rb
@@ -59,31 +59,35 @@ class SimpleInlineTextAnnotation
 
       case annotations.size
       when 1
-        label = match[2]
-        obj = get_obj_for(label)
-
-        @denotations << Denotation.new(begin_pos, end_pos, obj)
-
-        # Replace the processed annotation with its text content
-        full_text[match.begin(0)...match.end(0)] = target_text
-        :processed
+        process_single_annotation(begin_pos, end_pos, annotations[0])
       when 2
-        obj = annotations[1]
-        id = annotations[0]
-
-        @denotations << Denotation.new(begin_pos, end_pos, obj, id)
-
-        full_text[match.begin(0)...match.end(0)] = target_text
-        :processed
+        process_double_annotation(begin_pos, end_pos, annotations)
       when 4
-        @denotations << Denotation.new(begin_pos, end_pos, annotations[1], annotations[0])
-        @relations << { pred: annotations[2], subj: annotations[0], obj: annotations[3] }
-
-        full_text[match.begin(0)...match.end(0)] = target_text
-        :processed
+        process_quadruple_annotation(begin_pos, end_pos, annotations)
       else
-        :skipped
+        return :skipped
       end
+
+      full_text[match.begin(0)...match.end(0)] = target_text
+      :processed
+    end
+
+    def process_single_annotation(begin_pos, end_pos, label)
+      obj = get_obj_for(label)
+      @denotations << Denotation.new(begin_pos, end_pos, obj)
+    end
+
+    def process_double_annotation(begin_pos, end_pos, annotations)
+      id, label = annotations
+      obj = get_obj_for(label)
+      @denotations << Denotation.new(begin_pos, end_pos, obj, id)
+    end
+
+    def process_quadruple_annotation(begin_pos, end_pos, annotations)
+      subj, label, pred, obj2 = annotations
+      obj = get_obj_for(label)
+      @denotations << Denotation.new(begin_pos, end_pos, obj, subj)
+      @relations << { pred: pred, subj: subj, obj: obj2 }
     end
   end
 end

--- a/ruby/lib/simple_inline_text_annotation/parser.rb
+++ b/ruby/lib/simple_inline_text_annotation/parser.rb
@@ -55,13 +55,13 @@ class SimpleInlineTextAnnotation
       begin_pos = match.begin(0)
       end_pos = begin_pos + target_text.length
 
-      return match.end(0) unless process_annotation_by_size(match[2], begin_pos, end_pos)
+      return match.end(0) unless process_annotation(match[2], begin_pos, end_pos)
 
       full_text[match.begin(0)...match.end(0)] = target_text
       end_pos
     end
 
-    def process_annotation_by_size(annotations, begin_pos, end_pos)
+    def process_annotation(annotations, begin_pos, end_pos)
       annotations_array = annotations.split(", ")
 
       case annotations_array.size

--- a/ruby/lib/simple_inline_text_annotation/parser.rb
+++ b/ruby/lib/simple_inline_text_annotation/parser.rb
@@ -46,20 +46,19 @@ class SimpleInlineTextAnnotation
       current_pos = 0
 
       while (match = ANNOTATION_PATTERN.match(full_text, current_pos))
-        result = process_single_annotation(match, full_text)
-        current_pos = result == :processed ? match.begin(0) + match[1].length : match.end(0)
+        current_pos = process_annotation_and_update_position(match, full_text)
       end
     end
 
-    def process_single_annotation(match, full_text)
+    def process_annotation_and_update_position(match, full_text)
       target_text = match[1]
       begin_pos = match.begin(0)
       end_pos = begin_pos + target_text.length
 
-      return :skipped unless process_annotation_by_size(match[2], begin_pos, end_pos)
+      return match.end(0) unless process_annotation_by_size(match[2], begin_pos, end_pos)
 
       full_text[match.begin(0)...match.end(0)] = target_text
-      :processed
+      match.begin(0) + match[1].length
     end
 
     def process_annotation_by_size(annotations, begin_pos, end_pos)

--- a/ruby/lib/simple_inline_text_annotation/parser.rb
+++ b/ruby/lib/simple_inline_text_annotation/parser.rb
@@ -43,9 +43,11 @@ class SimpleInlineTextAnnotation
     end
 
     def process_denotations(full_text)
-      while full_text =~ DENOTATION_PATTERN
-        match = Regexp.last_match
-        process_single_denotation(match, full_text)
+      pos = 0
+
+      while match = DENOTATION_PATTERN.match(full_text, pos)
+        result = process_single_denotation(match, full_text)
+        pos = result == :processed ? match.begin(0) + match[1].length : match.end(0)
       end
     end
 
@@ -64,6 +66,7 @@ class SimpleInlineTextAnnotation
 
         # Replace the processed annotation with its text content
         full_text[match.begin(0)...match.end(0)] = target_text
+        :processed
       when 2
         obj = annotations[1]
         id = annotations[0]
@@ -71,12 +74,15 @@ class SimpleInlineTextAnnotation
         @denotations << Denotation.new(begin_pos, end_pos, obj, id)
 
         full_text[match.begin(0)...match.end(0)] = target_text
+        :processed
       when 4
         @denotations << Denotation.new(begin_pos, end_pos, annotations[1], annotations[0])
         @relations << { pred: annotations[2], subj: annotations[0], obj: annotations[3] }
 
         full_text[match.begin(0)...match.end(0)] = target_text
+        :processed
       else
+        :skipped
       end
     end
   end

--- a/ruby/lib/simple_inline_text_annotation/parser.rb
+++ b/ruby/lib/simple_inline_text_annotation/parser.rb
@@ -51,15 +51,13 @@ class SimpleInlineTextAnnotation
 
     def process_single_denotation(match, full_text)
       target_text = match[1]
+      begin_pos = match.begin(0)
+      end_pos = begin_pos + target_text.length
+      annotations = match[2].split(", ")
 
-      info = match[2].split(", ")
-
-      case info.size
+      case annotations.size
       when 1
         label = match[2]
-
-        begin_pos = match.begin(0)
-        end_pos = begin_pos + target_text.length
         obj = get_obj_for(label)
 
         @denotations << Denotation.new(begin_pos, end_pos, obj)
@@ -67,6 +65,12 @@ class SimpleInlineTextAnnotation
         # Replace the processed annotation with its text content
         full_text[match.begin(0)...match.end(0)] = target_text
       when 2
+        obj = annotations[1]
+        id = annotations[0]
+
+        @denotations << Denotation.new(begin_pos, end_pos, obj, id)
+
+        full_text[match.begin(0)...match.end(0)] = target_text
       when 4
       else
       end

--- a/ruby/lib/simple_inline_text_annotation/parser.rb
+++ b/ruby/lib/simple_inline_text_annotation/parser.rb
@@ -16,6 +16,7 @@ class SimpleInlineTextAnnotation
 
     def parse
       @denotations = []
+      @relations = []
       full_text = source_without_references
 
       process_denotations(full_text)
@@ -23,6 +24,7 @@ class SimpleInlineTextAnnotation
       SimpleInlineTextAnnotation.new(
         full_text,
         @denotations,
+        @relations.empty? ? nil : @relations,
         @entity_type_collection
       )
     end
@@ -49,16 +51,25 @@ class SimpleInlineTextAnnotation
 
     def process_single_denotation(match, full_text)
       target_text = match[1]
-      label = match[2]
 
-      begin_pos = match.begin(0)
-      end_pos = begin_pos + target_text.length
-      obj = get_obj_for(label)
+      info = match[2].split(", ")
 
-      @denotations << Denotation.new(begin_pos, end_pos, obj)
+      case info.size
+      when 1
+        label = match[2]
 
-      # Replace the processed annotation with its text content
-      full_text[match.begin(0)...match.end(0)] = target_text
+        begin_pos = match.begin(0)
+        end_pos = begin_pos + target_text.length
+        obj = get_obj_for(label)
+
+        @denotations << Denotation.new(begin_pos, end_pos, obj)
+
+        # Replace the processed annotation with its text content
+        full_text[match.begin(0)...match.end(0)] = target_text
+      when 2
+      when 4
+      else
+      end
     end
   end
 end

--- a/ruby/lib/simple_inline_text_annotation/parser.rb
+++ b/ruby/lib/simple_inline_text_annotation/parser.rb
@@ -58,7 +58,7 @@ class SimpleInlineTextAnnotation
       return match.end(0) unless process_annotation_by_size(match[2], begin_pos, end_pos)
 
       full_text[match.begin(0)...match.end(0)] = target_text
-      match.begin(0) + match[1].length
+      end_pos
     end
 
     def process_annotation_by_size(annotations, begin_pos, end_pos)

--- a/ruby/lib/simple_inline_text_annotation/parser.rb
+++ b/ruby/lib/simple_inline_text_annotation/parser.rb
@@ -72,6 +72,10 @@ class SimpleInlineTextAnnotation
 
         full_text[match.begin(0)...match.end(0)] = target_text
       when 4
+        @denotations << Denotation.new(begin_pos, end_pos, annotations[1], annotations[0])
+        @relations << { pred: annotations[2], subj: annotations[0], obj: annotations[3] }
+
+        full_text[match.begin(0)...match.end(0)] = target_text
       else
       end
     end

--- a/ruby/spec/simple_inline_text_annotation/parser_spec.rb
+++ b/ruby/spec/simple_inline_text_annotation/parser_spec.rb
@@ -293,7 +293,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
           ],
           "relations": [
             { "pred": "member_of", "subj": "T1", "obj": "T2" }
-          ],
+          ]
         }
       end
 
@@ -332,6 +332,24 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       end
 
       it "parse as entity types with ignoring white spaces" do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context "when the number of annotations is invalid" do
+      let(:source) do
+        "[Elon Musk][T1, Person, member_of, T2, Hoge] is a member of the " \
+        "[PayPal Mafia][T2, Organization, Fuga]."
+      end
+      let(:expected_format) do
+        {
+          "text": "[Elon Musk][T1, Person, member_of, T2, Hoge] is a member of the " \
+          "[PayPal Mafia][T2, Organization, Fuga].",
+          "denotations": []
+        }
+      end
+
+      it "brackets remain in the text" do
         is_expected.to eq(expected_format)
       end
     end

--- a/ruby/spec/simple_inline_text_annotation/parser_spec.rb
+++ b/ruby/spec/simple_inline_text_annotation/parser_spec.rb
@@ -354,6 +354,45 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       end
     end
 
+    context "when there are three consecutive brackets" do
+      context "and the second bracket has a valid number of elements" do
+        let(:source) do
+          "[Elon Musk][T1, Person, member_of, T2][Fuga] is a member of the PayPal Mafia."
+        end
+        let(:expected_format) do
+          {
+            "text": "Elon Musk[Fuga] is a member of the PayPal Mafia.",
+            "denotations": [
+              { "id": "T1", "span": { "begin": 0, "end": 9 }, "obj": "Person" }
+            ],
+            "relations": [
+              { "pred": "member_of", "subj": "T1", "obj": "T2" }
+            ]
+          }
+        end
+
+        it "processes the second bracket and ignores the third bracket" do
+          is_expected.to eq(expected_format)
+        end
+      end
+
+      context "and the second bracket has an invalid number of elements" do
+        let(:source) do
+          "[Elon Musk][T1, Person, member_of, T2, Hoge][Fuga] is a member of the PayPal Mafia."
+        end
+        let(:expected_format) do
+          {
+            "text": "[Elon Musk][T1, Person, member_of, T2, Hoge][Fuga] is a member of the PayPal Mafia.",
+            "denotations": []
+          }
+        end
+
+        it "skips the second bracket and ignores the third bracket" do
+          is_expected.to eq(expected_format)
+        end
+      end
+    end
+
     context "when parse is called multiple times" do
       let(:source) do
         <<~MD

--- a/ruby/spec/simple_inline_text_annotation/parser_spec.rb
+++ b/ruby/spec/simple_inline_text_annotation/parser_spec.rb
@@ -7,13 +7,16 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
     subject { SimpleInlineTextAnnotation.parse(source) }
 
     context "when source has annotation structure" do
-      let(:source) { "[Elon Musk][Person] is a member of the [PayPal Mafia][Organization]." }
+      let(:source) { "[Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization]." }
       let(:expected_format) do
         {
           "text": "Elon Musk is a member of the PayPal Mafia.",
           "denotations": [
-            { "span": { "begin": 0, "end": 9 }, "obj": "Person" },
-            { "span": { "begin": 29, "end": 41 }, "obj": "Organization" }
+            { "id": "T1", "span": { "begin": 0, "end": 9 }, "obj": "Person" },
+            { "id": "T2", "span": { "begin": 29, "end": 41 }, "obj": "Organization" }
+          ],
+          "relations": [
+            { "pred": "member_of", "subj": "T1", "obj": "T2" }
           ]
         }
       end
@@ -26,7 +29,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
     context "when surce has reference structure" do
       let(:source) do
         <<~MD2
-          [Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
+          [Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].
 
           [Person]: https://example.com/Person
           [Organization]: https://example.com/Organization
@@ -36,8 +39,11 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         {
           "text": "Elon Musk is a member of the PayPal Mafia.",
           "denotations": [
-            { "span": { "begin": 0, "end": 9 }, "obj": "https://example.com/Person" },
-            { "span": { "begin": 29, "end": 41 }, "obj": "https://example.com/Organization" }
+            { "id": "T1", "span": { "begin": 0, "end": 9 }, "obj": "https://example.com/Person" },
+            { "id": "T2", "span": { "begin": 29, "end": 41 }, "obj": "https://example.com/Organization" }
+          ],
+          "relations": [
+            { "pred": "member_of", "subj": "T1", "obj": "T2" }
           ],
           "config": {
             "entity types": [
@@ -54,12 +60,12 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
     end
 
     context "when source has metacharacter escape" do
-      let(:source) { '\[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].' }
+      let(:source) { '\[Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].' }
       let(:expected_format) do
         {
-          "text": "[Elon Musk][Person] is a member of the PayPal Mafia.",
+          "text": "[Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.",
           "denotations": [
-            { "span": { "begin": 40, "end": 52 }, "obj": "Organization" }
+            { "id": "T2", "span": { "begin": 59, "end": 71 }, "obj": "Organization" }
           ]
         }
       end
@@ -72,7 +78,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
     context "when reference definitions do not have a blank line above" do
       let(:source) do
         <<~MD2
-          [Elon Musk][Person] is a member of the PayPal Mafia.
+          [Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
           [Person]: https://example.com/Person
         MD2
       end
@@ -80,7 +86,10 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         {
           "text": "Elon Musk is a member of the PayPal Mafia.\n[Person]: https://example.com/Person",
           "denotations": [
-            { "span": { "begin": 0, "end": 9 }, "obj": "Person" }
+            { "id": "T1", "span": { "begin": 0, "end": 9 }, "obj": "Person" }
+          ],
+          "relations": [
+            { "pred": "member_of", "subj": "T1", "obj": "T2" }
           ]
         }
       end
@@ -93,7 +102,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
     context "when reference definitions have a blank line above" do
       let(:source) do
         <<~MD2
-          [Elon Musk][Person] is a member of the PayPal Mafia.
+          [Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
 
           [Person]: https://example.com/Person
         MD2
@@ -102,7 +111,10 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         {
           "text": "Elon Musk is a member of the PayPal Mafia.",
           "denotations": [
-            { "span": { "begin": 0, "end": 9 }, "obj": "https://example.com/Person" }
+            { "id": "T1", "span": { "begin": 0, "end": 9 }, "obj": "https://example.com/Person" }
+          ],
+          "relations": [
+            { "pred": "member_of", "subj": "T1", "obj": "T2" }
           ],
           "config": {
             "entity types": [
@@ -121,7 +133,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       context "when text is enclosed with quotation" do
         let(:source) do
           <<~MD2
-            [Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
+            [Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].
 
             [Person]: https://example.com/Person "text"
             [Organization]: https://example.com/Organization 'text'
@@ -131,8 +143,11 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
           {
             "text": "Elon Musk is a member of the PayPal Mafia.",
             "denotations": [
-              { "span": { "begin": 0, "end": 9 }, "obj": "https://example.com/Person" },
-              { "span": { "begin": 29, "end": 41 }, "obj": "https://example.com/Organization" }
+              { "id": "T1", "span": { "begin": 0, "end": 9 }, "obj": "https://example.com/Person" },
+              { "id": "T2", "span": { "begin": 29, "end": 41 }, "obj": "https://example.com/Organization" }
+            ],
+            "relations": [
+              { "pred": "member_of", "subj": "T1", "obj": "T2" }
             ],
             "config": {
               "entity types": [
@@ -151,7 +166,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       context "when text is not enclosed with quotation" do
         let(:source) do
           <<~MD2
-            [Elon Musk][Person] is a member of the PayPal Mafia.
+            [Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
 
             [Person]: https://example.com/Person text
           MD2
@@ -160,7 +175,10 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
           {
             "text": "Elon Musk is a member of the PayPal Mafia.\n\n[Person]: https://example.com/Person text",
             "denotations": [
-              { "span": { "begin": 0, "end": 9 }, "obj": "Person" }
+              { "id": "T1", "span": { "begin": 0, "end": 9 }, "obj": "Person" }
+            ],
+            "relations": [
+              { "pred": "member_of", "subj": "T1", "obj": "T2" }
             ]
           }
         end
@@ -174,7 +192,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
     context "when text is written below the reference definition" do
       let(:source) do
         <<~MD2
-          [Elon Musk][Person] is a member of the PayPal Mafia.
+          [Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
 
           [Person]: https://example.com/Person
           hello
@@ -184,7 +202,10 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         {
           "text": "Elon Musk is a member of the PayPal Mafia.\n\nhello",
           "denotations": [
-            { "span": { "begin": 0, "end": 9 }, "obj": "https://example.com/Person" }
+            { "id": "T1", "span": { "begin": 0, "end": 9 }, "obj": "https://example.com/Person" }
+          ],
+          "relations": [
+            { "pred": "member_of", "subj": "T1", "obj": "T2" }
           ],
           "config": {
             "entity types": [
@@ -202,7 +223,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
     context "when reference id is duplicated" do
       let(:source) do
         <<~MD2
-          [Elon Musk][Person] is a member of the PayPal Mafia.
+          [Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
 
           [Person]: https://example.com/Person
           [Person]: https://example.com/Organization
@@ -212,7 +233,10 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         {
           "text": "Elon Musk is a member of the PayPal Mafia.",
           "denotations": [
-            { "span": { "begin": 0, "end": 9 }, "obj": "https://example.com/Person" }
+            { "id": "T1", "span": { "begin": 0, "end": 9 }, "obj": "https://example.com/Person" }
+          ],
+          "relations": [
+            { "pred": "member_of", "subj": "T1", "obj": "T2" }
           ],
           "config": {
             "entity types": [
@@ -230,7 +254,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
     context "when reference label and id is same" do
       let(:source) do
         <<~MD2
-          [Elon Musk][Person] is a member of the PayPal Mafia.
+          [Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
 
           [Person]: Person
         MD2
@@ -239,7 +263,10 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         {
           "text": "Elon Musk is a member of the PayPal Mafia.",
           "denotations": [
-            { "span": { "begin": 0, "end": 9 }, "obj": "Person" }
+            { "id": "T1", "span": { "begin": 0, "end": 9 }, "obj": "Person" }
+          ],
+          "relations": [
+            { "pred": "member_of", "subj": "T1", "obj": "T2" }
           ]
         }
       end
@@ -252,7 +279,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
     context "when consecutive newlines in source" do
       let(:source) do
         <<~MD2
-          [Elon Musk][Person] is a member of the PayPal Mafia.
+          [Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
 
 
           Elon Musk is a member of the PayPal Mafia.
@@ -262,8 +289,11 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         {
           "text": "Elon Musk is a member of the PayPal Mafia.\n\nElon Musk is a member of the PayPal Mafia.",
           "denotations": [
-            { "span": { "begin": 0, "end": 9 }, "obj": "Person" }
-          ]
+            { "id": "T1", "span": { "begin": 0, "end": 9 }, "obj": "Person" }
+          ],
+          "relations": [
+            { "pred": "member_of", "subj": "T1", "obj": "T2" }
+          ],
         }
       end
 
@@ -276,7 +306,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       let(:source) do
         # Using <<- to create white spaces
         <<-MD2
-          [Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
+          [Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].
 
           [Person]: https://example.com/Person
           [Organization]: https://example.com/Organization
@@ -286,8 +316,11 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         {
           "text": "Elon Musk is a member of the PayPal Mafia.",
           "denotations": [
-            { "span": { "begin": 0, "end": 9 }, "obj": "https://example.com/Person" },
-            { "span": { "begin": 29, "end": 41 }, "obj": "https://example.com/Organization" }
+            { "id": "T1", "span": { "begin": 0, "end": 9 }, "obj": "https://example.com/Person" },
+            { "id": "T2", "span": { "begin": 29, "end": 41 }, "obj": "https://example.com/Organization" }
+          ],
+          "relations": [
+            { "pred": "member_of", "subj": "T1", "obj": "T2" }
           ],
           "config": {
             "entity types": [
@@ -306,7 +339,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
     context "when parse is called multiple times" do
       let(:source) do
         <<~MD
-          [Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
+          [Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].
 
           [Person]: https://example.com/Person
           [Organization]: https://example.com/Organization
@@ -317,8 +350,11 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         {
           "text": "Elon Musk is a member of the PayPal Mafia.",
           "denotations": [
-            { "span": { "begin": 0, "end": 9 }, "obj": "https://example.com/Person" },
-            { "span": { "begin": 29, "end": 41 }, "obj": "https://example.com/Organization" }
+            { "id": "T1", "span": { "begin": 0, "end": 9 }, "obj": "https://example.com/Person" },
+            { "id": "T2", "span": { "begin": 29, "end": 41 }, "obj": "https://example.com/Organization" }
+          ],
+          "relations": [
+            { "pred": "member_of", "subj": "T1", "obj": "T2" }
           ]
         }
       end


### PR DESCRIPTION
## 関連issue
#28 

## 概要

- rubyのparserメソッドを、リレーション記法に対応させました。

```ruby
source = "[Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization]." 
puts SimpleInlineTextAnnotation.parse(source)

# =>{
#         "text": "Elon Musk is a member of the PayPal Mafia.",
#         "denotations": [
#            { "id": "T1", "span": { "begin": 0, "end": 9 }, "obj": "Person" },
#            { "id": "T2", "span": { "begin": 29, "end": 41 }, "obj": "Organization" }
#          ],
#          "relations": [
#            { "pred": "member_of", "subj": "T1", "obj": "T2" }
#           ]
#         }

```

- 既存のテストをリレーション記法になるように修正しました。
- 二つ目の`[]`の中の要素が不正な数の時、変換せずにそのまま残っていることを確認するテストを追加しました。
- `[]`が3つ並んでいる場合のテストを追加しました。

## 動作確認

- 追加分のテストも含めた全てのテストが通ることを確認しました。

<img width="758" alt="スクリーンショット 2025-04-23 16 51 51" src="https://github.com/user-attachments/assets/29bbc7cf-1c88-47ae-b7fc-641846e16d0f" />

