### PR TITLE
Make the generator method compatible with relation notation for ruby

### DIFF
--- a/ruby/lib/simple_inline_text_annotation/denotation_validator.rb
+++ b/ruby/lib/simple_inline_text_annotation/denotation_validator.rb
@@ -2,7 +2,7 @@
 
 class SimpleInlineTextAnnotation
   module DenotationValidator
-    def validate(denotations, text_length)
+    def validate_denotations(denotations, text_length)
       result = remove_duplicates_from(denotations)
       result = remove_non_integer_positions_from(result)
       result = remove_negative_positions_from(result)

--- a/ruby/lib/simple_inline_text_annotation/generator.rb
+++ b/ruby/lib/simple_inline_text_annotation/generator.rb
@@ -43,7 +43,7 @@ class SimpleInlineTextAnnotation
       begin_pos = denotation.begin_pos
       end_pos = denotation.end_pos
       annotation = if denotation.id && !denotation.id.empty?
-                     get_annotations(denotation.obj, denotation.id)
+                     get_annotations(denotation)
                    else
                      get_obj(denotation.obj)
                    end
@@ -58,14 +58,14 @@ class SimpleInlineTextAnnotation
       @config["entity types"]&.select { |entity_type| entity_type.key?("label") }
     end
 
-    def get_annotations(obj, id)
+    def get_annotations(denotation)
       relations = @source["relations"] || []
-      relation = relations.find { |rel| rel["subj"] == id }
-      annotations = [id, obj, relation&.dig("pred"), relation&.dig("obj")]
+      relation = relations.find { |rel| rel["subj"] == denotation.id }
+      annotations = [denotation.id, denotation.obj, relation&.dig("pred"), relation&.dig("obj")]
 
       return annotations.compact.join(", ") unless labeled_entity_types
 
-      annotations[1] = get_obj(obj)
+      annotations[1] = get_obj(denotation.obj)
       annotations.compact.join(", ")
     end
 

--- a/ruby/lib/simple_inline_text_annotation/generator.rb
+++ b/ruby/lib/simple_inline_text_annotation/generator.rb
@@ -51,8 +51,8 @@ class SimpleInlineTextAnnotation
     end
 
     def get_annotations(obj, id)
-      relations = @source["relations"]
-      relation = relations&.find { |rel| rel["subj"] == id }
+      relations = @source["relations"] || []
+      relation = relations.find { |rel| rel["subj"] == id }
       annotations = [id, obj, relation&.dig("pred"), relation&.dig("obj")]
 
       return annotations.compact.join(", ") unless labeled_entity_types

--- a/ruby/lib/simple_inline_text_annotation/generator.rb
+++ b/ruby/lib/simple_inline_text_annotation/generator.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 require_relative "denotation"
+require_relative "relation_validator"
 
 class SimpleInlineTextAnnotation
   class Generator
     include DenotationValidator
+    include RelationValidator
 
     def initialize(source)
       @source = source.dup.freeze
@@ -16,7 +18,7 @@ class SimpleInlineTextAnnotation
       text = @source["text"]
       raise SimpleInlineTextAnnotation::GeneratorError, 'The "text" key is missing.' if text.nil?
 
-      denotations = validate(@denotations, text.length)
+      denotations = validate_denotations(@denotations, text.length)
 
       annotated_text = annotate_text(text, denotations)
       label_definitions = build_label_definitions
@@ -69,8 +71,8 @@ class SimpleInlineTextAnnotation
     end
 
     def find_valid_relation(denotation_id)
-      relations = @source["relations"] || []
-      relations.find { |rel| rel["subj"] == denotation_id && rel["obj"] && rel["pred"] }
+      relations = validate_relations(@source["relations"] || [])
+      relations.find { |rel| rel["subj"] == denotation_id }
     end
 
     def get_obj(obj)

--- a/ruby/lib/simple_inline_text_annotation/generator.rb
+++ b/ruby/lib/simple_inline_text_annotation/generator.rb
@@ -57,10 +57,13 @@ class SimpleInlineTextAnnotation
 
       return annotations.compact.join(", ") unless labeled_entity_types
 
-      entity = labeled_entity_types.find { |entity_type| entity_type["id"] == obj }
-      annotations[1] = entity["label"] if entity
-
+      annotations[1] = find_entity_label(obj)
       annotations.compact.join(", ")
+    end
+
+    def find_entity_label(obj)
+      entity = labeled_entity_types.find { |entity_type| entity_type["id"] == obj }
+      entity ? entity["label"] : obj
     end
 
     def build_label_definitions

--- a/ruby/lib/simple_inline_text_annotation/generator.rb
+++ b/ruby/lib/simple_inline_text_annotation/generator.rb
@@ -59,14 +59,18 @@ class SimpleInlineTextAnnotation
     end
 
     def get_annotations(denotation)
-      relations = @source["relations"] || []
-      relation = relations.find { |rel| rel["subj"] == denotation.id }
+      relation = find_valid_relation(denotation.id)
       annotations = [denotation.id, denotation.obj, relation&.dig("pred"), relation&.dig("obj")]
 
       return annotations.compact.join(", ") unless labeled_entity_types
 
       annotations[1] = get_obj(denotation.obj)
       annotations.compact.join(", ")
+    end
+
+    def find_valid_relation(denotation_id)
+      relations = @source["relations"] || []
+      relations.find { |rel| rel["subj"] == denotation_id && rel["obj"] && rel["pred"] }
     end
 
     def get_obj(obj)

--- a/ruby/lib/simple_inline_text_annotation/relation_validator.rb
+++ b/ruby/lib/simple_inline_text_annotation/relation_validator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class SimpleInlineTextAnnotation
+  module RelationValidator
+    def validate_relations(relations)
+      remove_incomplete_key_relations(relations)
+    end
+
+    private
+
+    def remove_incomplete_key_relations(relations)
+      relations.select { |relation| relation["subj"] && relation["pred"] && relation["obj"] }
+    end
+  end
+end

--- a/ruby/spec/simple_inline_text_annotation/generator_spec.rb
+++ b/ruby/spec/simple_inline_text_annotation/generator_spec.rb
@@ -55,6 +55,25 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
       end
     end
 
+    context "when source has denotations with ids but no relations" do
+      let(:source) do
+        {
+          "text" => "Elon Musk is a member of the PayPal Mafia.",
+          "denotations" => [
+            { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+            { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
+          ]
+        }
+      end
+      let(:expected_format) do
+        "[Elon Musk][T1, Person] is a member of the [PayPal Mafia][T2, Organization]."
+      end
+
+      it "displays ids in annotations even without relations" do
+        is_expected.to eq(expected_format)
+      end
+    end
+
     context "when source has denotations and relations" do
       let(:source) do
         {
@@ -155,7 +174,7 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         {
           "text" => "Elon Musk is a member of the PayPal Mafia.",
           "denotations" => [
-            { "id" => "T1", "span" => { "begin" => 0.1, "end" => 9.6 }, "obj" => "Person" }
+            { "span" => { "begin" => 0.1, "end" => 9.6 }, "obj" => "Person" }
           ]
         }
       end
@@ -172,15 +191,12 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         {
           "text" => "Elon Musk is a member of the PayPal Mafia.",
           "denotations" => [
-            { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
-            { "id" => "T2", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Organization" }
-          ],
-          "relations" => [
-            { "subj" => "T1", "pred" => "member_of", "obj" => "T2" }
+            { "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+            { "span" => { "begin" => 0, "end" => 9 }, "obj" => "Organization" }
           ]
         }
       end
-      let(:expected_format) { "[Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia." }
+      let(:expected_format) { "[Elon Musk][Person] is a member of the PayPal Mafia." }
 
       it "should use first denotation" do
         is_expected.to eq(expected_format)
@@ -193,15 +209,12 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
           {
             "text" => "Elon Musk is a member of the PayPal Mafia.",
             "denotations" => [
-              { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
-              { "id" => "T2", "span" => { "begin" => 2, "end" => 6 }, "obj" => "Organization" }
-            ],
-            "relations" => [
-              { "subj" => "T1", "pred" => "member_of", "obj" => "T2" }
+              { "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+              { "span" => { "begin" => 2, "end" => 6 }, "obj" => "Organization" }
             ]
           }
         end
-        let(:expected_format) { "[Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia." }
+        let(:expected_format) { "[Elon Musk][Person] is a member of the PayPal Mafia." }
 
         it "should use only outer denotation" do
           is_expected.to eq(expected_format)
@@ -213,12 +226,12 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
           {
             "text" => "Elon Musk is a member of the PayPal Mafia.",
             "denotations" => [
-              { "id" => "T1", "span" => { "begin" => 0, "end" => 4 }, "obj" => "First name" },
-              { "id" => "T2", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Full name" }
+              { "span" => { "begin" => 0, "end" => 4 }, "obj" => "First name" },
+              { "span" => { "begin" => 0, "end" => 9 }, "obj" => "Full name" }
             ]
           }
         end
-        let(:expected_format) { "[Elon Musk][T2, Full name] is a member of the PayPal Mafia." }
+        let(:expected_format) { "[Elon Musk][Full name] is a member of the PayPal Mafia." }
 
         it "should use only outer denotation" do
           is_expected.to eq(expected_format)
@@ -230,12 +243,12 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
           {
             "text" => "Elon Musk is a member of the PayPal Mafia.",
             "denotations" => [
-              { "id" => "T1", "span" => { "begin" => 6, "end" => 9 }, "obj" => "Last name" },
-              { "id" => "T2", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Full name" }
+              { "span" => { "begin" => 6, "end" => 9 }, "obj" => "Last name" },
+              { "span" => { "begin" => 0, "end" => 9 }, "obj" => "Full name" }
             ]
           }
         end
-        let(:expected_format) { "[Elon Musk][T2, Full name] is a member of the PayPal Mafia." }
+        let(:expected_format) { "[Elon Musk][Full name] is a member of the PayPal Mafia." }
 
         it "should use only outer denotation" do
           is_expected.to eq(expected_format)
@@ -248,8 +261,8 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         {
           "text" => "Elon Musk is a member of the PayPal Mafia.",
           "denotations" => [
-            { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
-            { "id" => "T2", "span" => { "begin" => 8, "end" => 11 }, "obj" => "Organization" }
+            { "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+            { "span" => { "begin" => 8, "end" => 11 }, "obj" => "Organization" }
           ]
         }
       end
@@ -265,7 +278,7 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         {
           "text" => "Elon Musk is a member of the PayPal Mafia.",
           "denotations" => [
-            { "id" => "T1", "span" => { "begin" => -1, "end" => 9 }, "obj" => "Person" }
+            { "span" => { "begin" => -1, "end" => 9 }, "obj" => "Person" }
           ]
         }
       end
@@ -281,7 +294,7 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         {
           "text" => "Elon Musk is a member of the PayPal Mafia.",
           "denotations" => [
-            { "subj" => "T1", "span" => { "begin" => 4, "end" => 0 }, "obj" => "Person" }
+            { "span" => { "begin" => 4, "end" => 0 }, "obj" => "Person" }
           ]
         }
       end
@@ -297,7 +310,7 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         {
           "text" => "Elon Musk is a member of the PayPal Mafia.",
           "denotations" => [
-            { "id" => "T1", "span" => { "begin" => 100, "end" => 200 }, "obj" => "Person" }
+            { "span" => { "begin" => 100, "end" => 200 }, "obj" => "Person" }
           ]
         }
       end
@@ -431,10 +444,7 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
       let(:source) do
         {
           "denotations" => [
-            { "id" => "T1", "span" => { "begin" => 4, "end" => 0 }, "obj" => "Person" }
-          ],
-          "relations" => [
-            { "subj" => "T1", "pred" => "part_of", "obj" => "T2" }
+            { "span" => { "begin" => 4, "end" => 0 }, "obj" => "Person" }
           ]
         }
       end

--- a/ruby/spec/simple_inline_text_annotation/generator_spec.rb
+++ b/ruby/spec/simple_inline_text_annotation/generator_spec.rb
@@ -11,12 +11,18 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         {
           "text" => "Elon Musk is a member of the PayPal Mafia.",
           "denotations" => [
-            { "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
-            { "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
+            { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+            { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
+          ],
+          "relations" => [
+            { "subj" => "T1", "pred" => "member_of", "obj" => "T2" }
           ]
         }
       end
-      let(:expected_format) { "[Elon Musk][Person] is a member of the [PayPal Mafia][Organization]." }
+      let(:expected_format) do
+        "[Elon Musk][T1, Person, member_of, T2] is a member of the " \
+        "[PayPal Mafia][T2, Organization]."
+      end
 
       it "generate annotation structure" do
         is_expected.to eq(expected_format)
@@ -28,8 +34,11 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         {
           "text" => "Elon Musk is a member of the PayPal Mafia.",
           "denotations" => [
-            { "span" => { "begin" => 0, "end" => 9 }, "obj" => "https://example.com/Person" },
-            { "span" => { "begin" => 29, "end" => 41 }, "obj" => "https://example.com/Organization" }
+            { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "https://example.com/Person" },
+            { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "https://example.com/Organization" }
+          ],
+          "relations" => [
+            { "subj" => "T1", "pred" => "member_of", "obj" => "T2" }
           ],
           "config" => {
             "entity types" => [
@@ -41,7 +50,7 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
       end
       let(:expected_format) do
         <<~MD2.chomp
-          [Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
+          [Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].
 
           [Person]: https://example.com/Person
           [Organization]: https://example.com/Organization
@@ -58,7 +67,10 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         {
           "text" => "Elon Musk is a member of the PayPal Mafia.",
           "denotations" => [
-            { "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" }
+            { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" }
+          ],
+          "relations" => [
+            { "subj" => "T1", "pred" => "member_of", "obj" => "T2" }
           ],
           "config" => {
             "entity types" => [
@@ -68,7 +80,7 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         }
       end
 
-      let(:expected_format) { "[Elon Musk][Person] is a member of the PayPal Mafia." }
+      let(:expected_format) { "[Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia." }
 
       it "should create only annotation structure" do
         is_expected.to eq(expected_format)
@@ -80,8 +92,11 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         {
           "text" => "Elon Musk is a member of the PayPal Mafia.",
           "denotations" => [
-            { "span" => { "begin" => 0.1, "end" => 9.6 }, "obj" => "Person" },
-            { "span" => { "begin" => "0", "end" => "9" }, "obj" => "Organization" }
+            { "id" => "T1", "span" => { "begin" => 0.1, "end" => 9.6 }, "obj" => "Person" },
+            { "id" => "T2", "span" => { "begin" => "0", "end" => "9" }, "obj" => "Organization" }
+          ],
+          "relations" => [
+            { "subj" => "T1", "pred" => "member_of", "obj" => "T2" }
           ]
         }
       end
@@ -98,12 +113,15 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         {
           "text" => "Elon Musk is a member of the PayPal Mafia.",
           "denotations" => [
-            { "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
-            { "span" => { "begin" => 0, "end" => 9 }, "obj" => "Organization" }
+            { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+            { "id" => "T2", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Organization" }
+          ],
+          "relations" => [
+            { "subj" => "T1", "pred" => "member_of", "obj" => "T2" }
           ]
         }
       end
-      let(:expected_format) { "[Elon Musk][Person] is a member of the PayPal Mafia." }
+      let(:expected_format) { "[Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia." }
 
       it "should use first denotation" do
         is_expected.to eq(expected_format)
@@ -116,12 +134,15 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
           {
             "text" => "Elon Musk is a member of the PayPal Mafia.",
             "denotations" => [
-              { "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
-              { "span" => { "begin" => 2, "end" => 6 }, "obj" => "Organization" }
+              { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+              { "id" => "T2", "span" => { "begin" => 2, "end" => 6 }, "obj" => "Organization" }
+            ],
+            "relations" => [
+              { "subj" => "T1", "pred" => "member_of", "obj" => "T2" }
             ]
           }
         end
-        let(:expected_format) { "[Elon Musk][Person] is a member of the PayPal Mafia." }
+        let(:expected_format) { "[Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia." }
 
         it "should use only outer denotation" do
           is_expected.to eq(expected_format)
@@ -133,12 +154,15 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
           {
             "text" => "Elon Musk is a member of the PayPal Mafia.",
             "denotations" => [
-              { "span" => { "begin" => 0, "end" => 4 }, "obj" => "First name" },
-              { "span" => { "begin" => 0, "end" => 9 }, "obj" => "Full name" }
+              { "id" => "T1", "span" => { "begin" => 0, "end" => 4 }, "obj" => "First name" },
+              { "id" => "T2", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Full name" }
+            ],
+            "relations" => [
+              { "subj" => "T1", "pred" => "part_of", "obj" => "T2" }
             ]
           }
         end
-        let(:expected_format) { "[Elon Musk][Full name] is a member of the PayPal Mafia." }
+        let(:expected_format) { "[Elon Musk][T2, Full name] is a member of the PayPal Mafia." }
 
         it "should use only outer denotation" do
           is_expected.to eq(expected_format)
@@ -150,12 +174,15 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
           {
             "text" => "Elon Musk is a member of the PayPal Mafia.",
             "denotations" => [
-              { "span" => { "begin" => 6, "end" => 9 }, "obj" => "Last name" },
-              { "span" => { "begin" => 0, "end" => 9 }, "obj" => "Full name" }
+              { "id" => "T1", "span" => { "begin" => 6, "end" => 9 }, "obj" => "Last name" },
+              { "id" => "T2", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Full name" }
+            ],
+            "relations" => [
+              { "subj" => "T1", "pred" => "part_of", "obj" => "T2" }
             ]
           }
         end
-        let(:expected_format) { "[Elon Musk][Full name] is a member of the PayPal Mafia." }
+        let(:expected_format) { "[Elon Musk][T2, Full name] is a member of the PayPal Mafia." }
 
         it "should use only outer denotation" do
           is_expected.to eq(expected_format)
@@ -168,8 +195,11 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         {
           "text" => "Elon Musk is a member of the PayPal Mafia.",
           "denotations" => [
-            { "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
-            { "span" => { "begin" => 8, "end" => 11 }, "obj" => "Organization" }
+            { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+            { "id" => "T2", "span" => { "begin" => 8, "end" => 11 }, "obj" => "Organization" }
+          ],
+          "relations" => [
+            { "subj" => "T1", "pred" => "part_of", "obj" => "T2" }
           ]
         }
       end
@@ -185,7 +215,10 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         {
           "text" => "Elon Musk is a member of the PayPal Mafia.",
           "denotations" => [
-            { "span" => { "begin" => -1, "end" => 9 }, "obj" => "Person" }
+            { "id" => "T1", "span" => { "begin" => -1, "end" => 9 }, "obj" => "Person" }
+          ],
+          "relations" => [
+            { "subj" => "T1", "pred" => "part_of", "obj" => "T2" }
           ]
         }
       end
@@ -201,7 +234,10 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         {
           "text" => "Elon Musk is a member of the PayPal Mafia.",
           "denotations" => [
-            { "span" => { "begin" => 4, "end" => 0 }, "obj" => "Person" }
+            { "subj" => "T1", "span" => { "begin" => 4, "end" => 0 }, "obj" => "Person" }
+          ],
+          "relations" => [
+            { "subj" => "T1", "pred" => "part_of", "obj" => "T2" }
           ]
         }
       end
@@ -217,7 +253,10 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         {
           "text" => "Elon Musk is a member of the PayPal Mafia.",
           "denotations" => [
-            { "span" => { "begin" => 100, "end" => 200 }, "obj" => "Person" }
+            { "id" => "T1", "span" => { "begin" => 100, "end" => 200 }, "obj" => "Person" }
+          ],
+          "relations" => [
+            { "subj" => "T1", "pred" => "part_of", "obj" => "T2" }
           ]
         }
       end
@@ -232,7 +271,10 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
       let(:source) do
         {
           "denotations" => [
-            { "span" => { "begin" => 4, "end" => 0 }, "obj" => "Person" }
+            { "id" => "T1", "span" => { "begin" => 4, "end" => 0 }, "obj" => "Person" }
+          ],
+          "relations" => [
+            { "subj" => "T1", "pred" => "part_of", "obj" => "T2" }
           ]
         }
       end

--- a/ruby/spec/simple_inline_text_annotation/generator_spec.rb
+++ b/ruby/spec/simple_inline_text_annotation/generator_spec.rb
@@ -309,7 +309,7 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
     end
 
     context "with relation" do
-      context "when denotation is invalid and relation is exist" do
+      context "when subject is invalid and relation exists" do
         let(:source) do
           {
             "text" => "Elon Musk is a member of the PayPal Mafia.",
@@ -343,12 +343,12 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         end
         let(:expected_format) { "Elon Musk is a member of the [PayPal Mafia][T2, Organization]." }
 
-        it "does not generate the relation due to invalid subject" do
+        it "does not generate the relation due to subject does not exist" do
           is_expected.to eq(expected_format)
         end
       end
 
-      context "when both subject and object are invalid" do
+      context "when both subject and object do not exist" do
         let(:source) do
           {
             "text" => "Elon Musk is a member of the PayPal Mafia.",
@@ -360,7 +360,7 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         end
         let(:expected_format) { "Elon Musk is a member of the PayPal Mafia." }
 
-        it "does not generate the relation due to both invalid subject and object" do
+        it "does not generate the relation because both subject and object do not exist" do
           is_expected.to eq(expected_format)
         end
       end

--- a/ruby/spec/simple_inline_text_annotation/generator_spec.rb
+++ b/ruby/spec/simple_inline_text_annotation/generator_spec.rb
@@ -11,6 +11,55 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         {
           "text" => "Elon Musk is a member of the PayPal Mafia.",
           "denotations" => [
+            { "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+            { "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
+          ]
+        }
+      end
+      let(:expected_format) do
+        "[Elon Musk][Person] is a member of the [PayPal Mafia][Organization]."
+      end
+
+      it "generate annotation structure" do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context "when source has config" do
+      let(:source) do
+        {
+          "text" => "Elon Musk is a member of the PayPal Mafia.",
+          "denotations" => [
+            { "span" => { "begin" => 0, "end" => 9 }, "obj" => "https://example.com/Person" },
+            { "span" => { "begin" => 29, "end" => 41 }, "obj" => "https://example.com/Organization" }
+          ],
+          "config" => {
+            "entity types" => [
+              { "id" => "https://example.com/Person", "label" => "Person" },
+              { "id" => "https://example.com/Organization", "label" => "Organization" }
+            ]
+          }
+        }
+      end
+      let(:expected_format) do
+        <<~MD2.chomp
+          [Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
+
+          [Person]: https://example.com/Person
+          [Organization]: https://example.com/Organization
+        MD2
+      end
+
+      it "generate label definition structure" do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context "when source has denotations and relations" do
+      let(:source) do
+        {
+          "text" => "Elon Musk is a member of the PayPal Mafia.",
+          "denotations" => [
             { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
             { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
           ],
@@ -29,7 +78,7 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
       end
     end
 
-    context "when source has config" do
+    context "when source includes entity config and relations" do
       let(:source) do
         {
           "text" => "Elon Musk is a member of the PayPal Mafia.",

--- a/ruby/spec/simple_inline_text_annotation/generator_spec.rb
+++ b/ruby/spec/simple_inline_text_annotation/generator_spec.rb
@@ -316,8 +316,8 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
         end
       end
 
-      context "when relation pred or obj is missing" do
-        context "when pred and obj are missing" do
+      context "when relation keys are missing" do
+        context "when subj is missing" do
           let(:source) do
             {
               "text" => "Elon Musk is a member of the PayPal Mafia.",
@@ -326,7 +326,7 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
                 { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
               ],
               "relations" => [
-                { "subj" => "T1" }
+                { "pred" => "member_of", "obj" => "T2" }
               ]
             }
           end

--- a/ruby/spec/simple_inline_text_annotation/generator_spec.rb
+++ b/ruby/spec/simple_inline_text_annotation/generator_spec.rb
@@ -87,16 +87,26 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
       end
     end
 
+    context "when denotation is missing" do
+      let(:source) do
+        {
+          "text" => "Elon Musk is a member of the PayPal Mafia.",
+          "denotations" => []
+        }
+      end
+      let(:expected_format) { "Elon Musk is a member of the PayPal Mafia." }
+
+      it "does not generate any denotation" do
+        is_expected.to eq(expected_format)
+      end
+    end
+
     context "when span value is not integer" do
       let(:source) do
         {
           "text" => "Elon Musk is a member of the PayPal Mafia.",
           "denotations" => [
-            { "id" => "T1", "span" => { "begin" => 0.1, "end" => 9.6 }, "obj" => "Person" },
-            { "id" => "T2", "span" => { "begin" => "0", "end" => "9" }, "obj" => "Organization" }
-          ],
-          "relations" => [
-            { "subj" => "T1", "pred" => "member_of", "obj" => "T2" }
+            { "id" => "T1", "span" => { "begin" => 0.1, "end" => 9.6 }, "obj" => "Person" }
           ]
         }
       end
@@ -156,9 +166,6 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
             "denotations" => [
               { "id" => "T1", "span" => { "begin" => 0, "end" => 4 }, "obj" => "First name" },
               { "id" => "T2", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Full name" }
-            ],
-            "relations" => [
-              { "subj" => "T1", "pred" => "part_of", "obj" => "T2" }
             ]
           }
         end
@@ -176,9 +183,6 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
             "denotations" => [
               { "id" => "T1", "span" => { "begin" => 6, "end" => 9 }, "obj" => "Last name" },
               { "id" => "T2", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Full name" }
-            ],
-            "relations" => [
-              { "subj" => "T1", "pred" => "part_of", "obj" => "T2" }
             ]
           }
         end
@@ -197,9 +201,6 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
           "denotations" => [
             { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
             { "id" => "T2", "span" => { "begin" => 8, "end" => 11 }, "obj" => "Organization" }
-          ],
-          "relations" => [
-            { "subj" => "T1", "pred" => "part_of", "obj" => "T2" }
           ]
         }
       end
@@ -216,9 +217,6 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
           "text" => "Elon Musk is a member of the PayPal Mafia.",
           "denotations" => [
             { "id" => "T1", "span" => { "begin" => -1, "end" => 9 }, "obj" => "Person" }
-          ],
-          "relations" => [
-            { "subj" => "T1", "pred" => "part_of", "obj" => "T2" }
           ]
         }
       end
@@ -264,6 +262,123 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
 
       it "should be ignored" do
         is_expected.to eq(expected_format)
+      end
+    end
+
+    context "when denotation is invalid and relation is exist" do
+      let(:source) do
+        {
+          "text" => "Elon Musk is a member of the PayPal Mafia.",
+          "denotations" => [
+            { "id" => "T1", "span" => { "begin" => 0.1, "end" => 9.6 }, "obj" => "Person" }
+          ],
+          "relations" => [
+            { "subj" => "T1", "pred" => "member_of", "obj" => "T2" }
+          ]
+        }
+      end
+
+      let(:expected_format) { "Elon Musk is a member of the PayPal Mafia." }
+
+      it "ignores the invalid denotation and its relation" do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context "when subject is invalid" do
+      let(:source) do
+        {
+          "text" => "Elon Musk is a member of the PayPal Mafia.",
+          "denotations" => [
+            { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
+          ],
+          "relations" => [
+            { "subj" => "T1", "pred" => "member_of", "obj" => "T2" }
+          ]
+        }
+      end
+      let(:expected_format) { "Elon Musk is a member of the [PayPal Mafia][T2, Organization]." }
+
+      it "does not generate the relation due to invalid subject" do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context "when both subject and object are invalid" do
+      let(:source) do
+        {
+          "text" => "Elon Musk is a member of the PayPal Mafia.",
+          "denotations" => [],
+          "relations" => [
+            { "subj" => "T1", "pred" => "member_of", "obj" => "T2" }
+          ]
+        }
+      end
+      let(:expected_format) { "Elon Musk is a member of the PayPal Mafia." }
+
+      it "does not generate the relation due to both invalid subject and object" do
+        is_expected.to eq(expected_format)
+      end
+    end
+
+    context "when relation pred or obj is missing" do
+      context "when pred and obj are missing" do
+        let(:source) do
+          {
+            "text" => "Elon Musk is a member of the PayPal Mafia.",
+            "denotations" => [
+              { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+              { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
+            ],
+            "relations" => [
+              { "subj" => "T1" }
+            ]
+          }
+        end
+        let(:expected_format) { "[Elon Musk][T1, Person] is a member of the [PayPal Mafia][T2, Organization]." }
+
+        it "does not generate the relation" do
+          is_expected.to eq(expected_format)
+        end
+      end
+
+      context "when pred is missing" do
+        let(:source) do
+          {
+            "text" => "Elon Musk is a member of the PayPal Mafia.",
+            "denotations" => [
+              { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+              { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
+            ],
+            "relations" => [
+              { "subj" => "T1", "obj" => "T2" }
+            ]
+          }
+        end
+        let(:expected_format) { "[Elon Musk][T1, Person] is a member of the [PayPal Mafia][T2, Organization]." }
+
+        it "does not generate the relation" do
+          is_expected.to eq(expected_format)
+        end
+      end
+
+      context "when obj is missing" do
+        let(:source) do
+          {
+            "text" => "Elon Musk is a member of the PayPal Mafia.",
+            "denotations" => [
+              { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" }
+            ],
+            "relations" => [
+              { "subj" => "T1", "pred" => "member_of" }
+            ]
+          }
+        end
+        let(:expected_format) { "[Elon Musk][T1, Person] is a member of the PayPal Mafia." }
+
+        it "does not generate the relation" do
+          is_expected.to eq(expected_format)
+        end
       end
     end
 

--- a/ruby/spec/simple_inline_text_annotation/generator_spec.rb
+++ b/ruby/spec/simple_inline_text_annotation/generator_spec.rb
@@ -233,9 +233,6 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
           "text" => "Elon Musk is a member of the PayPal Mafia.",
           "denotations" => [
             { "subj" => "T1", "span" => { "begin" => 4, "end" => 0 }, "obj" => "Person" }
-          ],
-          "relations" => [
-            { "subj" => "T1", "pred" => "part_of", "obj" => "T2" }
           ]
         }
       end
@@ -252,9 +249,6 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
           "text" => "Elon Musk is a member of the PayPal Mafia.",
           "denotations" => [
             { "id" => "T1", "span" => { "begin" => 100, "end" => 200 }, "obj" => "Person" }
-          ],
-          "relations" => [
-            { "subj" => "T1", "pred" => "part_of", "obj" => "T2" }
           ]
         }
       end
@@ -265,119 +259,121 @@ RSpec.describe SimpleInlineTextAnnotation::Generator, type: :model do
       end
     end
 
-    context "when denotation is invalid and relation is exist" do
-      let(:source) do
-        {
-          "text" => "Elon Musk is a member of the PayPal Mafia.",
-          "denotations" => [
-            { "id" => "T1", "span" => { "begin" => 0.1, "end" => 9.6 }, "obj" => "Person" }
-          ],
-          "relations" => [
-            { "subj" => "T1", "pred" => "member_of", "obj" => "T2" }
-          ]
-        }
-      end
-
-      let(:expected_format) { "Elon Musk is a member of the PayPal Mafia." }
-
-      it "ignores the invalid denotation and its relation" do
-        is_expected.to eq(expected_format)
-      end
-    end
-
-    context "when subject is invalid" do
-      let(:source) do
-        {
-          "text" => "Elon Musk is a member of the PayPal Mafia.",
-          "denotations" => [
-            { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
-          ],
-          "relations" => [
-            { "subj" => "T1", "pred" => "member_of", "obj" => "T2" }
-          ]
-        }
-      end
-      let(:expected_format) { "Elon Musk is a member of the [PayPal Mafia][T2, Organization]." }
-
-      it "does not generate the relation due to invalid subject" do
-        is_expected.to eq(expected_format)
-      end
-    end
-
-    context "when both subject and object are invalid" do
-      let(:source) do
-        {
-          "text" => "Elon Musk is a member of the PayPal Mafia.",
-          "denotations" => [],
-          "relations" => [
-            { "subj" => "T1", "pred" => "member_of", "obj" => "T2" }
-          ]
-        }
-      end
-      let(:expected_format) { "Elon Musk is a member of the PayPal Mafia." }
-
-      it "does not generate the relation due to both invalid subject and object" do
-        is_expected.to eq(expected_format)
-      end
-    end
-
-    context "when relation pred or obj is missing" do
-      context "when pred and obj are missing" do
+    context "with relation" do
+      context "when denotation is invalid and relation is exist" do
         let(:source) do
           {
             "text" => "Elon Musk is a member of the PayPal Mafia.",
             "denotations" => [
-              { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+              { "id" => "T1", "span" => { "begin" => 0.1, "end" => 9.6 }, "obj" => "Person" }
+            ],
+            "relations" => [
+              { "subj" => "T1", "pred" => "member_of", "obj" => "T2" }
+            ]
+          }
+        end
+
+        let(:expected_format) { "Elon Musk is a member of the PayPal Mafia." }
+
+        it "ignores the invalid denotation and its relation" do
+          is_expected.to eq(expected_format)
+        end
+      end
+
+      context "when subject does not exist" do
+        let(:source) do
+          {
+            "text" => "Elon Musk is a member of the PayPal Mafia.",
+            "denotations" => [
               { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
             ],
             "relations" => [
-              { "subj" => "T1" }
+              { "subj" => "T1", "pred" => "member_of", "obj" => "T2" }
             ]
           }
         end
-        let(:expected_format) { "[Elon Musk][T1, Person] is a member of the [PayPal Mafia][T2, Organization]." }
+        let(:expected_format) { "Elon Musk is a member of the [PayPal Mafia][T2, Organization]." }
 
-        it "does not generate the relation" do
+        it "does not generate the relation due to invalid subject" do
           is_expected.to eq(expected_format)
         end
       end
 
-      context "when pred is missing" do
+      context "when both subject and object are invalid" do
         let(:source) do
           {
             "text" => "Elon Musk is a member of the PayPal Mafia.",
-            "denotations" => [
-              { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
-              { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
-            ],
+            "denotations" => [],
             "relations" => [
-              { "subj" => "T1", "obj" => "T2" }
+              { "subj" => "T1", "pred" => "member_of", "obj" => "T2" }
             ]
           }
         end
-        let(:expected_format) { "[Elon Musk][T1, Person] is a member of the [PayPal Mafia][T2, Organization]." }
+        let(:expected_format) { "Elon Musk is a member of the PayPal Mafia." }
 
-        it "does not generate the relation" do
+        it "does not generate the relation due to both invalid subject and object" do
           is_expected.to eq(expected_format)
         end
       end
 
-      context "when obj is missing" do
-        let(:source) do
-          {
-            "text" => "Elon Musk is a member of the PayPal Mafia.",
-            "denotations" => [
-              { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" }
-            ],
-            "relations" => [
-              { "subj" => "T1", "pred" => "member_of" }
-            ]
-          }
-        end
-        let(:expected_format) { "[Elon Musk][T1, Person] is a member of the PayPal Mafia." }
+      context "when relation pred or obj is missing" do
+        context "when pred and obj are missing" do
+          let(:source) do
+            {
+              "text" => "Elon Musk is a member of the PayPal Mafia.",
+              "denotations" => [
+                { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+                { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
+              ],
+              "relations" => [
+                { "subj" => "T1" }
+              ]
+            }
+          end
+          let(:expected_format) { "[Elon Musk][T1, Person] is a member of the [PayPal Mafia][T2, Organization]." }
 
-        it "does not generate the relation" do
-          is_expected.to eq(expected_format)
+          it "does not generate the relation" do
+            is_expected.to eq(expected_format)
+          end
+        end
+
+        context "when pred is missing" do
+          let(:source) do
+            {
+              "text" => "Elon Musk is a member of the PayPal Mafia.",
+              "denotations" => [
+                { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+                { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
+              ],
+              "relations" => [
+                { "subj" => "T1", "obj" => "T2" }
+              ]
+            }
+          end
+          let(:expected_format) { "[Elon Musk][T1, Person] is a member of the [PayPal Mafia][T2, Organization]." }
+
+          it "does not generate the relation" do
+            is_expected.to eq(expected_format)
+          end
+        end
+
+        context "when obj is missing" do
+          let(:source) do
+            {
+              "text" => "Elon Musk is a member of the PayPal Mafia.",
+              "denotations" => [
+                { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" }
+              ],
+              "relations" => [
+                { "subj" => "T1", "pred" => "member_of" }
+              ]
+            }
+          end
+          let(:expected_format) { "[Elon Musk][T1, Person] is a member of the PayPal Mafia." }
+
+          it "does not generate the relation" do
+            is_expected.to eq(expected_format)
+          end
         end
       end
     end


### PR DESCRIPTION
## 関連issue
#28 

## 概要
generatorメソッドでハッシュで受け取ったデータをリレーション記法に変換できるようにしました。
既存のテストをリレーション記法に対応させました。


```ruby 
source = {
  "text" => "Elon Musk is a member of the PayPal Mafia.",
  "denotations" => [
    { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
    { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
  ],
  "relations" => [
    { "subj" => "T1", "pred" => "member_of", "obj" => "T2" }
  ]
}

puts SimpleInlineTextAnnotation.generate(source)

# => [Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].
```

## 動作確認

すべてのテストが通ることを確認しました。

<img width="844" alt="スクリーンショット 2025-04-25 13 03 03" src="https://github.com/user-attachments/assets/a2a9587f-e167-4b75-a7d6-24eb34928fed" />
