### PR TITLE
Make the parser method compatible with relation notation for js

### DIFF
--- a/js/__tests__/parser.denotation.test.mjs
+++ b/js/__tests__/parser.denotation.test.mjs
@@ -35,82 +35,37 @@ describe('SimpleInlineTextAnnotation.parse', () => {
     expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
 
-  test('should parse as denotation when source has annotation structure', () => {
-    const source = "[Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].";
-    const expected = {
-      text: "Elon Musk is a member of the PayPal Mafia.",
-      denotations: [
-        { id: "T1", span: { begin: 0, end: 9 }, obj: "Person" },
-        { id: "T2", span: { begin: 29, end: 41 }, obj: "Organization" }
-      ],
-      relations: [
-        { subj: "T1", pred: "member_of", obj: "T2" }
-      ]
-    };
-    expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
-  });
-
-  test('should parse as entity types and apply id to denotation obj when source has reference structure', () => {
-    const source = `[Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].
-
-[Person]: https://example.com/Person
-[Organization]: https://example.com/Organization`;
-    const expected = {
-      text: "Elon Musk is a member of the PayPal Mafia.",
-      denotations: [
-        { id: "T1", span: { begin: 0, end: 9 }, obj: "https://example.com/Person" },
-        { id: "T2", span: { begin: 29, end: 41 }, obj: "https://example.com/Organization" }
-      ],
-      relations: [
-        { subj: "T1", pred: "member_of", obj: "T2" }
-      ],
-      config: {
-        "entity types": [
-          { id: "https://example.com/Person", label: "Person" },
-          { id: "https://example.com/Organization", label: "Organization" }
-        ]
-      }
-    };
-    expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
-  });
-
   test('should not parse as annotation when source has metacharacter escape', () => {
-    const source = '\\[Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].';
+    const source = '\\[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].';
     const expected = {
-      text: "[Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.",
+      text: "[Elon Musk][Person] is a member of the PayPal Mafia.",
       denotations: [
-        { id: "T2", span: { begin: 59, end: 71 }, obj: "Organization" }
+        { span: { begin: 40, end: 52 }, obj: "Organization" }
       ]
     };
     expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
 
   test('should not use as references when reference definitions do not have a blank line above', () => {
-    const source = `[Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
+    const source = `[Elon Musk][Person] is a member of the PayPal Mafia.
 [Person]: https://example.com/Person`;
     const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.\n[Person]: https://example.com/Person",
       denotations: [
-        { id: "T1", span: { begin: 0, end: 9 }, obj: "Person" }
-      ],
-      relations: [
-        { subj: "T1", pred: "member_of", obj: "T2" }
+        { span: { begin: 0, end: 9 }, obj: "Person" }
       ]
     };
     expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
 
   test('should use definitions as references when reference definitions have a blank line above', () => {
-    const source = `[Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
+    const source = `[Elon Musk][Person] is a member of the PayPal Mafia.
 
 [Person]: https://example.com/Person`;
     const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.",
       denotations: [
-        { id: "T1", span: { begin: 0, end: 9 }, obj: "https://example.com/Person" }
-      ],
-      relations: [
-        { subj: "T1", pred: "member_of", obj: "T2" }
+        { span: { begin: 0, end: 9 }, obj: "https://example.com/Person" }
       ],
       config: {
         "entity types": [
@@ -122,18 +77,15 @@ describe('SimpleInlineTextAnnotation.parse', () => {
   });
 
   test('should parse as reference link when reference contains additional text enclosed with quotation', () => {
-    const source = `[Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].
+    const source = `[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
 
 [Person]: https://example.com/Person "text"
 [Organization]: https://example.com/Organization 'text'`;
     const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.",
       denotations: [
-        { id: "T1", span: { begin: 0, end: 9 }, obj: "https://example.com/Person" },
-        { id: "T2", span: { begin: 29, end: 41 }, obj: "https://example.com/Organization" }
-      ],
-      relations: [
-        { subj: "T1", pred: "member_of", obj: "T2" }
+        { span: { begin: 0, end: 9 }, obj: "https://example.com/Person" },
+        { span: { begin: 29, end: 41 }, obj: "https://example.com/Organization" }
       ],
       config: {
         "entity types": [
@@ -146,33 +98,27 @@ describe('SimpleInlineTextAnnotation.parse', () => {
   });
 
   test('should not parse as reference link when reference contains additional text not enclosed with quotation', () => {
-    const source = `[Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
+    const source = `[Elon Musk][Person] is a member of the PayPal Mafia.
 
 [Person]: https://example.com/Person text`;
     const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.\n\n[Person]: https://example.com/Person text",
       denotations: [
-        { id: "T1", span: { begin: 0, end: 9 }, obj: "Person" }
-      ],
-      relations: [
-        { subj: "T1", pred: "member_of", obj: "T2" }
+        { span: { begin: 0, end: 9 }, obj: "Person" }
       ]
     };
     expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
 
   test('should parse as expected format when text is written below the reference definition', () => {
-    const source = `[Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
+    const source = `[Elon Musk][Person] is a member of the PayPal Mafia.
 
 [Person]: https://example.com/Person
 hello`;
     const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.\n\nhello",
       denotations: [
-        { id: "T1", span: { begin: 0, end: 9 }, obj: "https://example.com/Person" }
-      ],
-      relations: [
-        { subj: "T1", pred: "member_of", obj: "T2" }
+        { span: { begin: 0, end: 9 }, obj: "https://example.com/Person" }
       ],
       config: {
         "entity types": [
@@ -184,17 +130,14 @@ hello`;
   });
 
   test('should use first defined id in priority when reference id is duplicated', () => {
-    const source = `[Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
+    const source = `[Elon Musk][Person] is a member of the PayPal Mafia.
 
 [Person]: https://example.com/Person
 [Person]: https://example.com/Organization`;
     const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.",
       denotations: [
-        { id: "T1", span: { begin: 0, end: 9 }, obj: "https://example.com/Person" }
-      ],
-      relations: [
-        { subj: "T1", pred: "member_of", obj: "T2" }
+        { span: { begin: 0, end: 9 }, obj: "https://example.com/Person" }
       ],
       config: {
         "entity types": [
@@ -206,51 +149,42 @@ hello`;
   });
 
   test('should not create config when reference label and id are the same', () => {
-    const source = `[Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
+    const source = `[Elon Musk][Person] is a member of the PayPal Mafia.
 
 [Person]: Person`;
     const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.",
       denotations: [
-        { id: "T1", span: { begin: 0, end: 9 }, obj: "Person" }
-      ],
-      relations: [
-        { subj: "T1", pred: "member_of", obj: "T2" }
+        { span: { begin: 0, end: 9 }, obj: "Person" }
       ]
     };
     expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
 
   test('should parse as single newline when consecutive newlines in source', () => {
-    const source = `[Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
+    const source = `[Elon Musk][Person] is a member of the PayPal Mafia.
 
 
 Elon Musk is a member of the PayPal Mafia.`;
     const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.\n\nElon Musk is a member of the PayPal Mafia.",
       denotations: [
-        { id: "T1", span: { begin: 0, end: 9 }, obj: "Person" }
-      ],
-      relations: [
-        { subj: "T1", pred: "member_of", obj: "T2" }
+        { span: { begin: 0, end: 9 }, obj: "Person" }
       ]
     };
     expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
 
   test('should parse as entity types with ignoring white spaces before reference definition', () => {
-    const source = `  [Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].
+    const source = `  [Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
 
   [Person]: https://example.com/Person
   [Organization]: https://example.com/Organization`;
     const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.",
       denotations: [
-        { id: "T1", span: { begin: 0, end: 9 }, obj: "https://example.com/Person" },
-        { id: "T2", span: { begin: 29, end: 41 }, obj: "https://example.com/Organization" }
-      ],
-      relations: [
-        { subj: "T1", pred: "member_of", obj: "T2" }
+        { span: { begin: 0, end: 9 }, obj: "https://example.com/Person" },
+        { span: { begin: 29, end: 41 }, obj: "https://example.com/Organization" }
       ],
       config: {
         "entity types": [
@@ -260,40 +194,6 @@ Elon Musk is a member of the PayPal Mafia.`;
       }
     };
     expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
-  });
-
-  test("should not convert brackets when the number of annotations in brackets is invalid", () => {
-    const source = "[Elon Musk][T1, Person, member_of, T2, Hoge] is a member of the [PayPal Mafia][T2, Organization, Fuga].";
-    const expected = {
-      text: "[Elon Musk][T1, Person, member_of, T2, Hoge] is a member of the [PayPal Mafia][T2, Organization, Fuga].",
-      denotations: []
-    };
-    expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
-  });
-
-  describe('when there are three consecutive brackets', () => {
-    it('should process valid annotations and ignore the third bracket', () => {
-      const source = "[Elon Musk][T1, Person, member_of, T2][Piyo] is a member of the PayPal Mafia.";
-      const expected = {
-        text: "Elon Musk[Piyo] is a member of the PayPal Mafia.",
-        denotations: [
-          { id: "T1", span: { begin: 0, end: 9 }, obj: "Person" }
-        ],
-        relations: [
-          { pred: "member_of", subj: "T1", obj: "T2" }
-        ]
-      };
-      expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
-    });
-
-    it('should skip invalid annotations and ignore the third bracket', () => {
-      const source = "[Elon Musk][T1, Person, member_of, T2, Hoge][Piyo] is a member of the PayPal Mafia.";
-      const expected = {
-        text: "[Elon Musk][T1, Person, member_of, T2, Hoge][Piyo] is a member of the PayPal Mafia.",
-        denotations: []
-      };
-      expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
-    });
   });
 });
 

--- a/js/__tests__/parser.relation.test.mjs
+++ b/js/__tests__/parser.relation.test.mjs
@@ -1,0 +1,76 @@
+import SimpleInlineTextAnnotation from '../src/index.mjs';
+
+describe('SimpleInlineTextAnnotation.parse', () => {
+  test('should parse as denotation when source has annotation structure', () => {
+    const source = "[Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].";
+    const expected = {
+      text: "Elon Musk is a member of the PayPal Mafia.",
+      denotations: [
+        { id: "T1", span: { begin: 0, end: 9 }, obj: "Person" },
+        { id: "T2", span: { begin: 29, end: 41 }, obj: "Organization" }
+      ],
+      relations: [
+        { subj: "T1", pred: "member_of", obj: "T2" }
+      ]
+    };
+    expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
+  });
+
+  test('should parse as entity types and apply id to denotation obj when source has reference structure', () => {
+    const source = `[Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].
+
+[Person]: https://example.com/Person
+[Organization]: https://example.com/Organization`;
+    const expected = {
+      text: "Elon Musk is a member of the PayPal Mafia.",
+      denotations: [
+        { id: "T1", span: { begin: 0, end: 9 }, obj: "https://example.com/Person" },
+        { id: "T2", span: { begin: 29, end: 41 }, obj: "https://example.com/Organization" }
+      ],
+      relations: [
+        { subj: "T1", pred: "member_of", obj: "T2" }
+      ],
+      config: {
+        "entity types": [
+          { id: "https://example.com/Person", label: "Person" },
+          { id: "https://example.com/Organization", label: "Organization" }
+        ]
+      }
+    };
+    expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
+  });
+
+  test("should not convert brackets when the number of annotations in brackets is invalid", () => {
+    const source = "[Elon Musk][T1, Person, member_of, T2, Hoge] is a member of the [PayPal Mafia][T2, Organization, Fuga].";
+    const expected = {
+      text: "[Elon Musk][T1, Person, member_of, T2, Hoge] is a member of the [PayPal Mafia][T2, Organization, Fuga].",
+      denotations: []
+    };
+    expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
+  });
+
+  describe('when there are three consecutive brackets', () => {
+    it('should process valid annotations and ignore the third bracket', () => {
+      const source = "[Elon Musk][T1, Person, member_of, T2][Piyo] is a member of the PayPal Mafia.";
+      const expected = {
+        text: "Elon Musk[Piyo] is a member of the PayPal Mafia.",
+        denotations: [
+          { id: "T1", span: { begin: 0, end: 9 }, obj: "Person" }
+        ],
+        relations: [
+          { pred: "member_of", subj: "T1", obj: "T2" }
+        ]
+      };
+      expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
+    });
+
+    it('should skip invalid annotations and ignore the third bracket', () => {
+      const source = "[Elon Musk][T1, Person, member_of, T2, Hoge][Piyo] is a member of the PayPal Mafia.";
+      const expected = {
+        text: "[Elon Musk][T1, Person, member_of, T2, Hoge][Piyo] is a member of the PayPal Mafia.",
+        denotations: []
+      };
+      expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
+    });
+  });
+});

--- a/js/__tests__/parser.test.mjs
+++ b/js/__tests__/parser.test.mjs
@@ -237,6 +237,31 @@ Elon Musk is a member of the PayPal Mafia.`;
     };
     expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
+
+  describe('when there are three consecutive brackets', () => {
+    it('should process valid annotations and ignore the third bracket', () => {
+      const source = "[Elon Musk][T1, Person, member_of, T2][Piyo] is a member of the PayPal Mafia.";
+      const expected = {
+        text: "Elon Musk[Piyo] is a member of the PayPal Mafia.",
+        denotations: [
+          { id: "T1", span: { begin: 0, end: 9 }, obj: "Person" }
+        ],
+        relations: [
+          { pred: "member_of", subj: "T1", obj: "T2" }
+        ]
+      };
+      expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
+    });
+
+    it('should skip invalid annotations and ignore the third bracket', () => {
+      const source = "[Elon Musk][T1, Person, member_of, T2, Hoge][Piyo] is a member of the PayPal Mafia.";
+      const expected = {
+        text: "[Elon Musk][T1, Person, member_of, T2, Hoge][Piyo] is a member of the PayPal Mafia.",
+        denotations: []
+      };
+      expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
+    });
+  });
 });
 
 describe('Parser', () => {

--- a/js/__tests__/parser.test.mjs
+++ b/js/__tests__/parser.test.mjs
@@ -3,27 +3,33 @@ import Parser from '../src/parser.mjs';
 
 describe('SimpleInlineTextAnnotation.parse', () => {
   test('should parse as denotation when source has annotation structure', () => {
-    const source = "[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].";
+    const source = "[Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].";
     const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.",
       denotations: [
-        { span: { begin: 0, end: 9 }, obj: "Person" },
-        { span: { begin: 29, end: 41 }, obj: "Organization" }
+        { id: "T1", span: { begin: 0, end: 9 }, obj: "Person" },
+        { id: "T2", span: { begin: 29, end: 41 }, obj: "Organization" }
+      ],
+      relations: [
+        { subj: "T1", pred: "member_of", obj: "T2" }
       ]
     };
     expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
 
   test('should parse as entity types and apply id to denotation obj when source has reference structure', () => {
-    const source = `[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
+    const source = `[Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].
 
 [Person]: https://example.com/Person
 [Organization]: https://example.com/Organization`;
     const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.",
       denotations: [
-        { span: { begin: 0, end: 9 }, obj: "https://example.com/Person" },
-        { span: { begin: 29, end: 41 }, obj: "https://example.com/Organization" }
+        { id: "T1", span: { begin: 0, end: 9 }, obj: "https://example.com/Person" },
+        { id: "T2", span: { begin: 29, end: 41 }, obj: "https://example.com/Organization" }
+      ],
+      relations: [
+        { subj: "T1", pred: "member_of", obj: "T2" }
       ],
       config: {
         "entity types": [
@@ -36,36 +42,42 @@ describe('SimpleInlineTextAnnotation.parse', () => {
   });
 
   test('should not parse as annotation when source has metacharacter escape', () => {
-    const source = '\\[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].';
+    const source = '\\[Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].';
     const expected = {
-      text: "[Elon Musk][Person] is a member of the PayPal Mafia.",
+      text: "[Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.",
       denotations: [
-        { span: { begin: 40, end: 52 }, obj: "Organization" }
+        { id: "T2", span: { begin: 59, end: 71 }, obj: "Organization" }
       ]
     };
     expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
 
   test('should not use as references when reference definitions do not have a blank line above', () => {
-    const source = `[Elon Musk][Person] is a member of the PayPal Mafia.
+    const source = `[Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
 [Person]: https://example.com/Person`;
     const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.\n[Person]: https://example.com/Person",
       denotations: [
-        { span: { begin: 0, end: 9 }, obj: "Person" }
+        { id: "T1", span: { begin: 0, end: 9 }, obj: "Person" }
+      ],
+      relations: [
+        { subj: "T1", pred: "member_of", obj: "T2" }
       ]
     };
     expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
 
   test('should use definitions as references when reference definitions have a blank line above', () => {
-    const source = `[Elon Musk][Person] is a member of the PayPal Mafia.
+    const source = `[Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
 
 [Person]: https://example.com/Person`;
     const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.",
       denotations: [
-        { span: { begin: 0, end: 9 }, obj: "https://example.com/Person" }
+        { id: "T1", span: { begin: 0, end: 9 }, obj: "https://example.com/Person" }
+      ],
+      relations: [
+        { subj: "T1", pred: "member_of", obj: "T2" }
       ],
       config: {
         "entity types": [
@@ -77,15 +89,18 @@ describe('SimpleInlineTextAnnotation.parse', () => {
   });
 
   test('should parse as reference link when reference contains additional text enclosed with quotation', () => {
-    const source = `[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
+    const source = `[Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].
 
 [Person]: https://example.com/Person "text"
 [Organization]: https://example.com/Organization 'text'`;
     const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.",
       denotations: [
-        { span: { begin: 0, end: 9 }, obj: "https://example.com/Person" },
-        { span: { begin: 29, end: 41 }, obj: "https://example.com/Organization" }
+        { id: "T1", span: { begin: 0, end: 9 }, obj: "https://example.com/Person" },
+        { id: "T2", span: { begin: 29, end: 41 }, obj: "https://example.com/Organization" }
+      ],
+      relations: [
+        { subj: "T1", pred: "member_of", obj: "T2" }
       ],
       config: {
         "entity types": [
@@ -98,27 +113,33 @@ describe('SimpleInlineTextAnnotation.parse', () => {
   });
 
   test('should not parse as reference link when reference contains additional text not enclosed with quotation', () => {
-    const source = `[Elon Musk][Person] is a member of the PayPal Mafia.
+    const source = `[Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
 
 [Person]: https://example.com/Person text`;
     const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.\n\n[Person]: https://example.com/Person text",
       denotations: [
-        { span: { begin: 0, end: 9 }, obj: "Person" }
+        { id: "T1", span: { begin: 0, end: 9 }, obj: "Person" }
+      ],
+      relations: [
+        { subj: "T1", pred: "member_of", obj: "T2" }
       ]
     };
     expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
 
   test('should parse as expected format when text is written below the reference definition', () => {
-    const source = `[Elon Musk][Person] is a member of the PayPal Mafia.
+    const source = `[Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
 
 [Person]: https://example.com/Person
 hello`;
     const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.\n\nhello",
       denotations: [
-        { span: { begin: 0, end: 9 }, obj: "https://example.com/Person" }
+        { id: "T1", span: { begin: 0, end: 9 }, obj: "https://example.com/Person" }
+      ],
+      relations: [
+        { subj: "T1", pred: "member_of", obj: "T2" }
       ],
       config: {
         "entity types": [
@@ -130,14 +151,17 @@ hello`;
   });
 
   test('should use first defined id in priority when reference id is duplicated', () => {
-    const source = `[Elon Musk][Person] is a member of the PayPal Mafia.
+    const source = `[Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
 
 [Person]: https://example.com/Person
 [Person]: https://example.com/Organization`;
     const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.",
       denotations: [
-        { span: { begin: 0, end: 9 }, obj: "https://example.com/Person" }
+        { id: "T1", span: { begin: 0, end: 9 }, obj: "https://example.com/Person" }
+      ],
+      relations: [
+        { subj: "T1", pred: "member_of", obj: "T2" }
       ],
       config: {
         "entity types": [
@@ -149,42 +173,51 @@ hello`;
   });
 
   test('should not create config when reference label and id are the same', () => {
-    const source = `[Elon Musk][Person] is a member of the PayPal Mafia.
+    const source = `[Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
 
 [Person]: Person`;
     const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.",
       denotations: [
-        { span: { begin: 0, end: 9 }, obj: "Person" }
+        { id: "T1", span: { begin: 0, end: 9 }, obj: "Person" }
+      ],
+      relations: [
+        { subj: "T1", pred: "member_of", obj: "T2" }
       ]
     };
     expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
 
   test('should parse as single newline when consecutive newlines in source', () => {
-    const source = `[Elon Musk][Person] is a member of the PayPal Mafia.
+    const source = `[Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
 
 
 Elon Musk is a member of the PayPal Mafia.`;
     const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.\n\nElon Musk is a member of the PayPal Mafia.",
       denotations: [
-        { span: { begin: 0, end: 9 }, obj: "Person" }
+        { id: "T1", span: { begin: 0, end: 9 }, obj: "Person" }
+      ],
+      relations: [
+        { subj: "T1", pred: "member_of", obj: "T2" }
       ]
     };
     expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
 
   test('should parse as entity types with ignoring white spaces before reference definition', () => {
-    const source = `  [Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
+    const source = `  [Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].
 
   [Person]: https://example.com/Person
   [Organization]: https://example.com/Organization`;
     const expected = {
       text: "Elon Musk is a member of the PayPal Mafia.",
       denotations: [
-        { span: { begin: 0, end: 9 }, obj: "https://example.com/Person" },
-        { span: { begin: 29, end: 41 }, obj: "https://example.com/Organization" }
+        { id: "T1", span: { begin: 0, end: 9 }, obj: "https://example.com/Person" },
+        { id: "T2", span: { begin: 29, end: 41 }, obj: "https://example.com/Organization" }
+      ],
+      relations: [
+        { subj: "T1", pred: "member_of", obj: "T2" }
       ],
       config: {
         "entity types": [
@@ -199,7 +232,7 @@ Elon Musk is a member of the PayPal Mafia.`;
 
 describe('Parser', () => {
   test('should not accumulate denotations when parse is called multiple times', () => {
-    const source = `[Elon Musk][Person] is a member of the [PayPal Mafia][Organization].
+    const source = `[Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].
 
 [Person]: https://example.com/Person
 [Organization]: https://example.com/Organization`;
@@ -209,8 +242,8 @@ describe('Parser', () => {
     const result = parser.parse().toObject();
 
     expect(result.denotations).toEqual([
-      { span: { begin: 0, end: 9 }, obj: "https://example.com/Person" },
-      { span: { begin: 29, end: 41 }, obj: "https://example.com/Organization" },
+      { id: "T1", span: { begin: 0, end: 9 }, obj: "https://example.com/Person" },
+      { id: "T2", span: { begin: 29, end: 41 }, obj: "https://example.com/Organization" },
     ]);
   });
 });

--- a/js/__tests__/parser.test.mjs
+++ b/js/__tests__/parser.test.mjs
@@ -228,6 +228,15 @@ Elon Musk is a member of the PayPal Mafia.`;
     };
     expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
   });
+
+  test("should not convert brackets when the number of annotations in brackets is invalid", () => {
+    const source = "[Elon Musk][T1, Person, member_of, T2, Hoge] is a member of the [PayPal Mafia][T2, Organization, Fuga].";
+    const expected = {
+      text: "[Elon Musk][T1, Person, member_of, T2, Hoge] is a member of the [PayPal Mafia][T2, Organization, Fuga].",
+      denotations: []
+    };
+    expect(SimpleInlineTextAnnotation.parse(source)).toStrictEqual(expected);
+  });
 });
 
 describe('Parser', () => {

--- a/js/src/denotation.mjs
+++ b/js/src/denotation.mjs
@@ -2,11 +2,13 @@ class Denotation {
   #beginPos;
   #endPos;
   #obj;
+  #id;
 
-  constructor(beginPos, endPos, obj) {
+  constructor(beginPos, endPos, obj, id = null) {
     this.#beginPos = beginPos;
     this.#endPos = endPos;
     this.#obj = obj;
+    this.#id = id;
   }
 
   get beginPos() {
@@ -21,12 +23,20 @@ class Denotation {
     return this.#obj;
   }
 
+  get id() {
+    return this.#id;
+  }
+
   get span() {
     return { begin: this.#beginPos, end: this.#endPos };
   }
 
   toObject() {
-    return { span: this.span, obj: this.#obj };
+    const result = { span: this.span, obj: this.#obj };
+    if (this.#id) {
+      result.id = this.#id;
+    }
+    return result;
   }
 
   isNestedWithin(other) {

--- a/js/src/index.mjs
+++ b/js/src/index.mjs
@@ -6,11 +6,13 @@ const ESCAPE_PATTERN = /\\(?=\[[^\]]+\]\[[^\]]+\])/;
 class SimpleInlineTextAnnotation {
   #text;
   #denotations;
+  #relations;
   #entityTypeCollection;
 
-  constructor(text, denotations, entityTypeCollection) {
+  constructor(text, denotations, relations, entityTypeCollection) {
     this.#text = text;
     this.#denotations = denotations;
+    this.#relations = relations;
     this.#entityTypeCollection = entityTypeCollection;
   }
 
@@ -31,6 +33,10 @@ class SimpleInlineTextAnnotation {
       text: this.#formatText(this.#text),
       denotations: this.#denotations.map((d) => d.toObject()),
     };
+
+    if (this.#relations && this.#relations.length > 0) {
+      result.relations = this.#relations
+    }
 
     const config = this.#config();
     if (config && Object.keys(config).length > 0 && !Object.values(config).every((v) => v == null || (Array.isArray(v) && v.length === 0))) {

--- a/js/src/parser.mjs
+++ b/js/src/parser.mjs
@@ -47,8 +47,7 @@ class Parser {
 
   #processDenotations(fullText) {
     const regex = new RegExp(DENOTATION_PATTERN, 'g');
-    let match;
-    let obj;
+    let match, obj, label, id, subj, pred, obj2;
 
     while ((match = regex.exec(fullText)) !== null) {
       const targetText = match[1];
@@ -63,12 +62,16 @@ class Parser {
 
           break;
         case 2:
-          const [id, label] = annotations;
+          [id, label] = annotations;
           obj = this.#getObjFor(label);
 
           this.#denotations.push(new Denotation(beginPos, endPos, obj, id));
           break;
         case 4:
+          [subj, label, pred, obj2] = annotations;
+          obj = this.#getObjFor(label);
+          this.#denotations.push(new Denotation(beginPos, endPos, obj, subj));
+          this.#relations.push({ pred: pred, subj: subj, obj: obj2 });
 
           break;
         default:
@@ -76,6 +79,7 @@ class Parser {
       }
 
       fullText = fullText.slice(0, match.index) + targetText + fullText.slice(match.index + match[0].length);
+      regex.lastIndex = endPos;
     }
 
     return fullText;

--- a/js/src/parser.mjs
+++ b/js/src/parser.mjs
@@ -47,7 +47,7 @@ class Parser {
 
   #processDenotations(fullText) {
     const regex = new RegExp(DENOTATION_PATTERN, 'g');
-    let match, obj, label, id, subj, pred, obj2;
+    let match;
 
     while ((match = regex.exec(fullText)) !== null) {
       const targetText = match[1];
@@ -57,21 +57,15 @@ class Parser {
 
       switch (annotations.length) {
         case 1:
-          obj = this.#getObjFor(annotations[0]);
-          this.#denotations.push(new Denotation(beginPos, endPos, obj));
+          this.#processSingleAnnotation(beginPos, endPos, annotations);
           break;
 
         case 2:
-          [id, label] = annotations;
-          obj = this.#getObjFor(label);
-          this.#denotations.push(new Denotation(beginPos, endPos, obj, id));
+          this.#processDoubleAnnotation(beginPos, endPos, annotations);
           break;
 
         case 4:
-          [subj, label, pred, obj2] = annotations;
-          obj = this.#getObjFor(label);
-          this.#denotations.push(new Denotation(beginPos, endPos, obj, subj));
-          this.#relations.push({ pred: pred, subj: subj, obj: obj2 });
+          this.#processRelationAnnotation(beginPos, endPos, annotations);
           break;
 
         default:
@@ -84,6 +78,24 @@ class Parser {
     }
 
     return fullText;
+  }
+
+  #processSingleAnnotation(beginPos, endPos, annotations) {
+    const obj = this.#getObjFor(annotations[0]);
+    this.#denotations.push(new Denotation(beginPos, endPos, obj));
+  }
+
+  #processDoubleAnnotation(beginPos, endPos, annotations) {
+    const [id, label] = annotations;
+    const obj = this.#getObjFor(label);
+    this.#denotations.push(new Denotation(beginPos, endPos, obj, id));
+  }
+
+  #processRelationAnnotation(beginPos, endPos, annotations) {
+    const [subj, label, pred, obj2] = annotations;
+    const obj = this.#getObjFor(label);
+    this.#denotations.push(new Denotation(beginPos, endPos, obj, subj));
+    this.#relations.push({ pred, subj, obj: obj2 });
   }
 }
 

--- a/js/src/parser.mjs
+++ b/js/src/parser.mjs
@@ -59,23 +59,24 @@ class Parser {
         case 1:
           obj = this.#getObjFor(annotations[0]);
           this.#denotations.push(new Denotation(beginPos, endPos, obj));
-
           break;
+
         case 2:
           [id, label] = annotations;
           obj = this.#getObjFor(label);
-
           this.#denotations.push(new Denotation(beginPos, endPos, obj, id));
           break;
+
         case 4:
           [subj, label, pred, obj2] = annotations;
           obj = this.#getObjFor(label);
           this.#denotations.push(new Denotation(beginPos, endPos, obj, subj));
           this.#relations.push({ pred: pred, subj: subj, obj: obj2 });
-
           break;
+
         default:
-          return "skipped";
+          regex.lastIndex = endPos;
+          continue;
       }
 
       fullText = fullText.slice(0, match.index) + targetText + fullText.slice(match.index + match[0].length);

--- a/js/src/parser.mjs
+++ b/js/src/parser.mjs
@@ -55,6 +55,8 @@ class Parser {
       const endPos = beginPos + targetText.length;
       const annotations = match[2].split(', ');
 
+      regex.lastIndex = endPos;
+
       switch (annotations.length) {
         case 1:
           this.#processSingleAnnotation(beginPos, endPos, annotations);
@@ -69,12 +71,10 @@ class Parser {
           break;
 
         default:
-          regex.lastIndex = endPos;
           continue;
       }
 
       fullText = fullText.slice(0, match.index) + targetText + fullText.slice(match.index + match[0].length);
-      regex.lastIndex = endPos;
     }
 
     return fullText;

--- a/js/src/parser.mjs
+++ b/js/src/parser.mjs
@@ -48,6 +48,7 @@ class Parser {
   #processDenotations(fullText) {
     const regex = new RegExp(DENOTATION_PATTERN, 'g');
     let match;
+    let obj;
 
     while ((match = regex.exec(fullText)) !== null) {
       const targetText = match[1];
@@ -57,18 +58,24 @@ class Parser {
 
       switch (annotations.length) {
         case 1:
-          const obj = this.#getObjFor(annotations[0]);
+          obj = this.#getObjFor(annotations[0]);
           this.#denotations.push(new Denotation(beginPos, endPos, obj));
 
-          fullText = fullText.slice(0, match.index) + targetText + fullText.slice(match.index + match[0].length);
           break;
         case 2:
+          const [id, label] = annotations;
+          obj = this.#getObjFor(label);
+
+          this.#denotations.push(new Denotation(beginPos, endPos, obj, id));
           break;
         case 4:
+
           break;
         default:
           return "skipped";
       }
+
+      fullText = fullText.slice(0, match.index) + targetText + fullText.slice(match.index + match[0].length);
     }
 
     return fullText;

--- a/js/src/parser.mjs
+++ b/js/src/parser.mjs
@@ -10,6 +10,7 @@ class Parser {
   #source;
   #denotations;
   #entityTypeCollection;
+  #relations;
 
   constructor(source) {
     this.#source = source;
@@ -18,6 +19,7 @@ class Parser {
 
   parse() {
     this.#denotations = [];
+    this.#relations = [];
     let fullText = this.#sourceWithoutReferences();
 
     fullText = this.#processDenotations(fullText);
@@ -25,6 +27,7 @@ class Parser {
     return new SimpleInlineTextAnnotation(
       fullText,
       this.#denotations,
+      this.#relations,
       this.#entityTypeCollection
     );
   }
@@ -48,16 +51,24 @@ class Parser {
 
     while ((match = regex.exec(fullText)) !== null) {
       const targetText = match[1];
-      const label = match[2];
-
       const beginPos = match.index;
       const endPos = beginPos + targetText.length;
+      const annotations = match[2].split(', ');
 
-      const obj = this.#getObjFor(label);
+      switch (annotations.length) {
+        case 1:
+          const obj = this.#getObjFor(annotations[0]);
+          this.#denotations.push(new Denotation(beginPos, endPos, obj));
 
-      this.#denotations.push(new Denotation(beginPos, endPos, obj));
-
-      fullText = fullText.slice(0, match.index) + targetText + fullText.slice(match.index + match[0].length);
+          fullText = fullText.slice(0, match.index) + targetText + fullText.slice(match.index + match[0].length);
+          break;
+        case 2:
+          break;
+        case 4:
+          break;
+        default:
+          return "skipped";
+      }
     }
 
     return fullText;


### PR DESCRIPTION
## 関連issue
#28 

## 概要

- js版のparserメソッドをリレーション記法に対応させました。

```js
import SimpleInlineTextAnnotation from 'simple-inline-text-annotation'

const result = SimpleInlineTextAnnotation.parse(`[Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].

[Person]: https://example.com/Person
[Organization]: https://example.com/Organization`);
// Output:
// {
//   "text": "Elon Musk is a member of the PayPal Mafia.",
//   "denotations": [
//     { "id": "T1", "span": { "begin": 0, "end": 9 }, "obj": "https://example.com/Person" },
//     { "id": "T2", "span": { "begin": 29, "end": 41 }, "obj": "https://example.com/Organization" }
//   ],
//   "relations": [
//     { "pred": "member_of", "subj": "T1", "obj": "T2" },
//   ],
//   "config": {
//     "entity types": [
//       { "id": "https://example.com/Person", "label": "Person" },
//       { "id": "https://example.com/Organization", "label": "Organization" }
//     ]
//   }
// }


```

- 既存のテストをリレーション記法に対応させました。
- 二つ目の[]の中の要素が不正な数の時、変換せずにそのまま残っていることを確認するテストを追加しました。


## 動作確認
追加分を含めた全てのparserメソッド関連のテストが通ることを確認しました。

<img width="1064" alt="スクリーンショット 2025-04-28 17 40 09" src="https://github.com/user-attachments/assets/d49c76e8-6a98-43f7-8406-4e13d70403ad" />

