### PR TITLE
Add documentation for relation notation in README

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -107,3 +107,92 @@ The `generate` method takes an object with the following structure:
   - `"id"`: The unique identifier for the entity type.
   - `"label"`: The human-readable label for the entity type.
 
+## Relation Notation
+
+The `SimpleInlineTextAnnotation` gem supports advanced relation notation, allowing you to define relationships between annotated entities. This is achieved by interpreting the second set of square brackets (`[]`) based on the number of elements it contains.
+
+### Parsing Rules
+
+- If the second `[]` contains **1 element**, it is treated as the annotation type (default behavior).
+- If the second `[]` contains **2 elements**, the first element is interpreted as the `id` of the denotation, and the second element as the `obj` (annotation type).
+- If the second `[]` contains **4 elements**, the elements are interpreted as follows:
+  1. The first element is the `id` of the denotation and the `subj` of the relation.
+  2. The second element is the `obj` (annotation type) of the denotation.
+  3. The third element is the `pred` (predicate) of the relation.
+  4. The fourth element is the `obj` of the relation.
+- Any other cases are ignored.
+
+### Example
+
+```js
+import SimpleInlineTextAnnotation from 'simple-inline-text-annotation'
+
+const result = SimpleInlineTextAnnotation.parse("[Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].");
+console.log(result);
+
+// Output:
+// {
+//   "text": "Elon Musk is a member of the PayPal Mafia.",
+//   "denotations": [
+//     { "id": "T1", "span": { "begin": 0, "end": 9 }, "obj": "Person" },
+//     { "id": "T2", "span": { "begin": 29, "end": 41 }, "obj": "Organization" }
+//   ],
+//   "relations": [
+//     { "pred": "member_of", "subj": "T1", "obj": "T2" },
+//   ]
+// }
+```
+
+### Explanation
+
+- The input string `[Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].` contains:
+  1. Two denotations:
+     - `[Elon Musk][T1, Person, member_of, T2]`: The text `Elon Musk` is annotated as `Person` with `id` `T1`. It also serves as the `subj` of the relation.
+     - `[PayPal Mafia][T2, Organization]`: The text `PayPal Mafia` is annotated as `Organization` with `id` `T2`.
+  2. One relation:
+     - `member_of`: Indicates that `T1` (`Elon Musk`) is a member of `T2` (`PayPal Mafia`).
+
+- The method returns a hash with:
+  - `"text"`: The plain text without annotations.
+  - `"denotations"`: An array of hashes, where each hash contains:
+    - `"id"`: The unique identifier of the denotation.
+    - `"span"`: The character positions (`begin` and `end`) of the annotated text.
+    - `"obj"`: The annotation type.
+  - `"relations"`: An array of hashes, where each hash contains:
+    - `"pred"`: The predicate or type of the relation.
+    - `"subj"`: The `id` of the subject denotation.
+    - `"obj"`: The `id` of the object denotation.
+
+### Generating Relation Notation
+
+The `generate` method can also create strings with relation notations from structured data.
+
+```js
+import SimpleInlineTextAnnotation from 'simple-inline-text-annotation'
+
+const input = {
+  text: "Elon Musk is a member of the PayPal Mafia.",
+  denotations: [
+    { span: { begin: 0, end: 9 }, obj: "Person" },
+    { span: { begin: 29, end: 41 }, obj: "Organization" }
+  ],
+  relations:[
+    { pred: "member_of", subj: "T1", obj: "T2"}
+  ]
+};
+
+const result = SimpleInlineTextAnnotation.generate(input);
+console.log(result);
+// Output:
+// [Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].
+```
+
+### Explanation
+
+- The input object includes:
+  - `"text"`: The plain text.
+  - `"denotations"`: An array of annotations with `id`, `span`, and `obj`.
+  - `"relations"`: An array of relationships, where:
+    - `"subj"` and `"obj"` reference `id`s in the `denotations` array.
+    - `"pred"` specifies the relationship type.
+- The method generates a string with inline annotations and relationships.

--- a/js/README.md
+++ b/js/README.md
@@ -107,9 +107,9 @@ The `generate` method takes an object with the following structure:
   - `"id"`: The unique identifier for the entity type.
   - `"label"`: The human-readable label for the entity type.
 
-## Relation Notation
+## Relation Annotation
 
-The `SimpleInlineTextAnnotation` gem supports advanced relation notation, allowing you to define relationships between annotated entities. This is achieved by interpreting the second set of square brackets (`[]`) based on the number of elements it contains.
+The `SimpleInlineTextAnnotation` gem supports advanced relation annotation, allowing you to define relationships between annotated entities. This is achieved by interpreting the second set of square brackets (`[]`) based on the number of elements it contains.
 
 ### Parsing Rules
 
@@ -163,9 +163,9 @@ console.log(result);
     - `"subj"`: The `id` of the subject denotation.
     - `"obj"`: The `id` of the object denotation.
 
-### Generating Relation Notation
+### Generating Relation Annotation
 
-The `generate` method can also create strings with relation notations from structured data.
+The `generate` method can also create strings with relation annotations from structured data.
 
 ```js
 import SimpleInlineTextAnnotation from 'simple-inline-text-annotation'

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -79,9 +79,9 @@ puts result
   - The text specified in `"span"` is enclosed in square brackets `[]`.
   - The annotation type specified in `"obj"` is added in a second set of square brackets `[]`.
 
-## Relation Notation
+## Relation Annotation
 
-The `SimpleInlineTextAnnotation` gem supports advanced relation notation, allowing you to define relationships between annotated entities. This is achieved by interpreting the second set of square brackets (`[]`) based on the number of elements it contains.
+The `SimpleInlineTextAnnotation` gem supports advanced relation annotation, allowing you to define relationships between annotated entities. This is achieved by interpreting the second set of square brackets (`[]`) based on the number of elements it contains.
 
 #### Parsing Rules
 
@@ -132,9 +132,9 @@ puts result
     - `"subj"`: The `id` of the subject denotation.
     - `"obj"`: The `id` of the object denotation.
 
-### Generating Relation Notation
+### Generating Relation Annotation
 
-The `generate` method can also create strings with relation notations from structured data.
+The `generate` method can also create strings with relation annotations from structured data.
 
 ```ruby
 result = SimpleInlineTextAnnotation.generate({

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -78,3 +78,85 @@ puts result
 - The method generates a string where:
   - The text specified in `"span"` is enclosed in square brackets `[]`.
   - The annotation type specified in `"obj"` is added in a second set of square brackets `[]`.
+
+## Relation Notation
+
+The `SimpleInlineTextAnnotation` gem supports advanced relation notation, allowing you to define relationships between annotated entities. This is achieved by interpreting the second set of square brackets (`[]`) based on the number of elements it contains.
+
+#### Parsing Rules
+
+- If the second `[]` contains **1 element**, it is treated as the annotation type (default behavior).
+- If the second `[]` contains **2 elements**, the first element is interpreted as the `id` of the denotation, and the second element as the `obj` (annotation type).
+- If the second `[]` contains **4 elements**, the elements are interpreted as follows:
+  1. The first element is the `id` of the denotation and the `subj` of the relation.
+  2. The second element is the `obj` (annotation type) of the denotation.
+  3. The third element is the `pred` (predicate) of the relation.
+  4. The fourth element is the `obj` of the relation.
+- Any other cases are ignored.
+
+### Example
+
+```ruby
+source = "[Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization]."
+result = SimpleInlineTextAnnotation.parse(source)
+puts result
+# => {
+#      text: "Elon Musk is a member of the PayPal Mafia.",
+#      denotations: [
+#        { id: "T1", span: { begin: 0, end: 9 }, obj: "Person" },
+#        { id: "T2", span: { begin: 29, end: 41 }, obj: "Organization" }
+#      ],
+#      relations: [
+#        { pred: "member_of", subj: "T1", obj: "T2" }
+#      ]
+#    }
+```
+
+### Explanation
+
+- The input string `[Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].` contains:
+  1. Two denotations:
+     - `[Elon Musk][T1, Person, member_of, T2]`: The text `Elon Musk` is annotated as `Person` with `id` `T1`. It also serves as the `subj` of the relation.
+     - `[PayPal Mafia][T2, Organization]`: The text `PayPal Mafia` is annotated as `Organization` with `id` `T2`.
+  2. One relation:
+     - `member_of`: Indicates that `T1` (`Elon Musk`) is a member of `T2` (`PayPal Mafia`).
+
+- The method returns a hash with:
+  - `"text"`: The plain text without annotations.
+  - `"denotations"`: An array of hashes, where each hash contains:
+    - `"id"`: The unique identifier of the denotation.
+    - `"span"`: The character positions (`begin` and `end`) of the annotated text.
+    - `"obj"`: The annotation type.
+  - `"relations"`: An array of hashes, where each hash contains:
+    - `"pred"`: The predicate or type of the relation.
+    - `"subj"`: The `id` of the subject denotation.
+    - `"obj"`: The `id` of the object denotation.
+
+### Generating Relation Notation
+
+The `generate` method can also create strings with relation notations from structured data.
+
+```ruby
+result = SimpleInlineTextAnnotation.generate({
+  "text" => "Elon Musk is a member of the PayPal Mafia.",
+  "denotations" => [
+    { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+    { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
+  ],
+  "relations" => [
+    { "pred" => "member_of", "subj" => "T1", "obj" => "T2" }
+  ]
+})
+puts result
+# => "[Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization]."
+```
+
+#### Explanation
+
+- The input hash includes:
+  - `"text"`: The plain text.
+  - `"denotations"`: An array of annotations with `id`, `span`, and `obj`.
+  - `"relations"`: An array of relationships, where:
+    - `"subj"` and `"obj"` reference `id`s in the `denotations` array.
+    - `"pred"` specifies the relationship type.
+- The method generates a string with inline annotations and relationships.


### PR DESCRIPTION
## 関連issue
#28 

## 概要
リレーション記法についてrubyとjsそれぞれのREADMEに追記