### PR TITLE
Fix issues causing gem and npm package release failures

### DIFF
--- a/.github/workflows/gem_release.yml
+++ b/.github/workflows/gem_release.yml
@@ -4,23 +4,28 @@ on:
   workflow_dispatch:
 
 jobs:
+  run-tests:
+    uses: ./.github/workflows/ruby_test.yml
+    with:
+      ruby-version: '3.4.2'
+
   release:
     name: Release to RubyGems
+    needs: run-tests
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run Tests
-        uses: ./.github/workflows/ruby_test.yml
-        with:
-          ruby-version: '3.4.2'
-
       - name: Build gem
-        run: gem build ruby/simple_inline_text_annotation.gemspec
+        run: |
+          cd ruby
+          gem build simple_inline_text_annotation.gemspec
 
       - name: Publish to Rubygems
         env:
           RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
-        run: gem push ruby/simple_inline_text_annotation-*.gem
+        run: |
+          cd ruby
+          gem push simple_inline_text_annotation-*.gem

--- a/.github/workflows/npm_release.yml
+++ b/.github/workflows/npm_release.yml
@@ -4,7 +4,14 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  run-tests:
+    uses: ./.github/workflows/npm_test.yml
+    with:
+      node-version: '20'
+
+  publish:
+    name: Publish to npm
+    needs: run-tests
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -24,11 +31,6 @@ jobs:
         run: |
           cd js
           npm ci
-
-      - name: Run Tests
-        uses: ./.github/workflows/npm_test.yml
-        with:
-          node-version: '20'
 
       - name: Publish to npm
         env:


### PR DESCRIPTION
## 概要

gemおよびnpmパッケージをpublishにしようとしたところ、両方テストを実行するところで同じエラーが出て失敗してしまいました。

失敗したワークフロー:
- https://github.com/Tamada-Arino/simple-inline-text-annotation/actions/runs/14878001523/job/41779152618
- https://github.com/Tamada-Arino/simple-inline-text-annotation/actions/runs/14878143281/job/41779611197

調査したところ、再利用可能なワークフロー(テストの実行)はstepではなくjobとして呼び出す必要があるとのことだったので、対応しています

参考:
https://github.com/orgs/community/discussions/27362
https://docs.github.com/ja/actions/sharing-automations/reusing-workflows#calling-a-reusable-workflow


## 動作確認

現状できておりません。