### PR TITLE
Update gem release workflow to use credentials file for authentication

### DIFF
--- a/.github/workflows/gem_release.yml
+++ b/.github/workflows/gem_release.yml
@@ -18,7 +18,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Publish to Rubygems
+      # Publish the gem to RubyGems
+      # Reference: https://docs.github.com/ja/actions/use-cases-and-examples/building-and-testing/building-and-testing-ruby#publishing-gems
+      - name: Publish to RubyGems
         env:
           RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
         run: |

--- a/.github/workflows/gem_release.yml
+++ b/.github/workflows/gem_release.yml
@@ -18,14 +18,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Build gem
-        run: |
-          cd ruby
-          gem build simple_inline_text_annotation.gemspec
-
       - name: Publish to Rubygems
         env:
           RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
         run: |
           cd ruby
-          gem push simple_inline_text_annotation-*.gem
+          mkdir -p .gem
+          printf -- "---\n:rubygems_api_key: ${RUBYGEMS_API_KEY}\n" > .gem/credentials
+          chmod 0600 .gem/credentials
+          gem build simple_inline_text_annotation.gemspec
+          gem push simple_inline_text_annotation-*.gem --config-file .gem/credentials


### PR DESCRIPTION
## 概要

RubyGems.orgにpushする際`error: Invalid credentials`が発生する問題の対応を行います。
https://github.com/Tamada-Arino/simple-inline-text-annotation/actions/runs/14896587773/job/41840215115

このエラーはAPIキーの設定が不足していることが原因のようなので、対応を行いました。

参考
https://docs.github.com/ja/actions/use-cases-and-examples/building-and-testing/building-and-testing-ruby#publishing-gems

## 動作確認

現状できておりません。